### PR TITLE
test: add unit test for create database with zero retention policy

### DIFF
--- a/opengemini/database_test.go
+++ b/opengemini/database_test.go
@@ -29,6 +29,13 @@ func TestClientCreateDatabaseWithRpSuccess(t *testing.T) {
 	require.Nil(t, err)
 }
 
+func TestClientCreateDatabaseWithRpZeroSuccess(t *testing.T) {
+	c := testDefaultClient(t)
+	databaseName := randomDatabaseName()
+	err := c.CreateDatabaseWithRp(databaseName, RpConfig{Name: "test4", Duration: "0", ShardGroupDuration: "1h", IndexDuration: "7h"})
+	require.NotNil(t, err)
+}
+
 func TestClientCreateDatabaseWithRpInvalid(t *testing.T) {
 	c := testDefaultClient(t)
 	databaseName := randomDatabaseName()


### PR DESCRIPTION
Create an unit test example to test whether it can work properly when the retention policy is set as zero