### PR TITLE
fix: make point serialization in line with line protocol

### DIFF
--- a/opengemini/point.go
+++ b/opengemini/point.go
@@ -1,7 +1,8 @@
 package opengemini
 
 import (
-	"fmt"
+	"io"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -70,25 +71,6 @@ func (p *Point) SetMeasurement(name string) {
 	p.Measurement = name
 }
 
-func (p *Point) String() string {
-	if len(p.Measurement) == 0 || p.Fields == nil {
-		return ""
-	}
-	var builder strings.Builder
-	builder.WriteString(p.Measurement)
-	if p.Tags != nil {
-		builder.WriteByte(',')
-		builder.WriteString(parseTags(p.Tags))
-	}
-	builder.WriteByte(' ')
-	builder.WriteString(parseFields(p.Fields))
-	if !p.Time.IsZero() {
-		builder.WriteByte(' ')
-		builder.WriteString(parseTimestamp(p.Precision, p.Time))
-	}
-	return builder.String()
-}
-
 type BatchPoints struct {
 	Points []*Point
 }
@@ -97,69 +79,186 @@ func (bp *BatchPoints) AddPoint(p *Point) {
 	bp.Points = append(bp.Points, p)
 }
 
-func parseTags(tags map[string]string) string {
-	var builder strings.Builder
-
-	first := true
-	for k, v := range tags {
-		if !first {
-			builder.WriteByte(',')
-		} else {
-			first = false
-		}
-		builder.WriteString(k)
-		builder.WriteByte('=')
-		builder.WriteString(v)
-	}
-
-	return builder.String()
+type LineProtocolEncoder struct {
+	w io.Writer
 }
 
-func parseFields(fields map[string]interface{}) string {
-	var builder strings.Builder
+func NewLineProtocolEncoder(w io.Writer) *LineProtocolEncoder {
+	return &LineProtocolEncoder{w: w}
+}
 
-	first := true
-	for k, v := range fields {
-		if !first {
-			builder.WriteByte(',')
-		} else {
-			first = false
-		}
-		builder.WriteString(k)
-		builder.WriteByte('=')
-		switch v := v.(type) {
-		case string:
-			builder.WriteString("\"" + v + "\"")
-		case int8, uint8, int16, uint16, int, uint, int32, uint32, int64, uint64:
-			builder.WriteString(fmt.Sprintf("%di", v))
-		case float32, float64:
-			builder.WriteString(fmt.Sprintf("%f", v))
-		case bool:
-			if v {
-				builder.WriteByte('T')
-			} else {
-				builder.WriteByte('F')
+func (enc *LineProtocolEncoder) writeByte(b byte) error {
+	_, err := enc.w.Write([]byte{b})
+	return err
+}
+
+func (enc *LineProtocolEncoder) writeString(s string, charsToEscape string) error {
+	if !strings.ContainsAny(s, charsToEscape) {
+		_, err := io.WriteString(enc.w, s)
+		return err
+	}
+
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if strings.IndexByte(charsToEscape, c) != -1 {
+			if err := enc.writeByte('\\'); err != nil {
+				return err
 			}
 		}
-
+		if err := enc.writeByte(c); err != nil {
+			return err
+		}
 	}
-	return builder.String()
+
+	return nil
 }
 
-func parseTimestamp(precisionType PrecisionType, ptime time.Time) string {
-	switch precisionType {
+func (enc *LineProtocolEncoder) writeFieldValue(v interface{}) error {
+	var err error
+
+	switch v := v.(type) {
+	case string:
+		err = enc.writeString(v, `"\`)
+	case int8:
+		if _, err = io.WriteString(enc.w, strconv.FormatInt(int64(v), 10)); err == nil {
+			err = enc.writeByte('i')
+		}
+	case uint8:
+		if _, err = io.WriteString(enc.w, strconv.FormatUint(uint64(v), 10)); err == nil {
+			err = enc.writeByte('u')
+		}
+	case int16:
+		if _, err = io.WriteString(enc.w, strconv.FormatInt(int64(v), 10)); err == nil {
+			err = enc.writeByte('i')
+		}
+	case uint16:
+		if _, err = io.WriteString(enc.w, strconv.FormatUint(uint64(v), 10)); err == nil {
+			err = enc.writeByte('u')
+		}
+	case int32:
+		if _, err = io.WriteString(enc.w, strconv.FormatInt(int64(v), 10)); err == nil {
+			err = enc.writeByte('i')
+		}
+	case uint32:
+		if _, err = io.WriteString(enc.w, strconv.FormatUint(uint64(v), 10)); err == nil {
+			err = enc.writeByte('u')
+		}
+	case int:
+		if _, err = io.WriteString(enc.w, strconv.FormatInt(int64(v), 10)); err == nil {
+			err = enc.writeByte('i')
+		}
+	case uint:
+		if _, err = io.WriteString(enc.w, strconv.FormatUint(uint64(v), 10)); err == nil {
+			err = enc.writeByte('u')
+		}
+	case int64:
+		if _, err = io.WriteString(enc.w, strconv.FormatInt(v, 10)); err == nil {
+			err = enc.writeByte('i')
+		}
+	case uint64:
+		if _, err = io.WriteString(enc.w, strconv.FormatUint(v, 10)); err == nil {
+			err = enc.writeByte('u')
+		}
+	case float32:
+		_, err = io.WriteString(enc.w, strconv.FormatFloat(float64(v), 'f', -1, 32))
+	case float64:
+		_, err = io.WriteString(enc.w, strconv.FormatFloat(v, 'f', -1, 64))
+	case bool:
+		if v {
+			err = enc.writeByte('T')
+		} else {
+			err = enc.writeByte('F')
+		}
+	default:
+		panic("unsupported field value type")
+	}
+
+	return err
+}
+
+func (enc *LineProtocolEncoder) Encode(p *Point) error {
+	if len(p.Measurement) == 0 || p.Fields == nil {
+		return nil
+	}
+
+	if err := enc.writeString(p.Measurement, `, \`); err != nil {
+		return err
+	}
+
+	for k, v := range p.Tags {
+		if err := enc.writeByte(','); err != nil {
+			return err
+		}
+		if err := enc.writeString(k, `, =\`); err != nil {
+			return err
+		}
+		if err := enc.writeByte('='); err != nil {
+			return err
+		}
+		if err := enc.writeString(v, `, =\`); err != nil {
+			return err
+		}
+	}
+
+	sep := byte(' ')
+	for k, v := range p.Fields {
+		if err := enc.writeByte(sep); err != nil {
+			return err
+		}
+		sep = ','
+
+		if err := enc.writeString(k, `, =\`); err != nil {
+			return err
+		}
+		if err := enc.writeByte('='); err != nil {
+			return err
+		}
+		if err := enc.writeFieldValue(v); err != nil {
+			return err
+		}
+	}
+
+	if !p.Time.IsZero() {
+		if err := enc.writeByte(' '); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(enc.w, formatTimestamp(p.Time, p.Precision)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (enc *LineProtocolEncoder) BatchEncode(bp *BatchPoints) error {
+	for _, p := range bp.Points {
+		if p == nil {
+			continue
+		}
+		if err := enc.Encode(p); err != nil {
+			return err
+		}
+		if err := enc.writeByte('\n'); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func formatTimestamp(t time.Time, p PrecisionType) string {
+	switch p {
 	case PrecisionNanoSecond:
-		return fmt.Sprintf("%d", ptime.UnixNano())
+		return strconv.FormatInt(t.UnixNano(), 10)
 	case PrecisionMicrosecond:
-		return fmt.Sprintf("%d", ptime.Round(time.Microsecond).UnixNano())
+		return strconv.FormatInt(t.Round(time.Microsecond).UnixNano(), 10)
 	case PrecisionMillisecond:
-		return fmt.Sprintf("%d", ptime.Round(time.Millisecond).UnixNano())
+		return strconv.FormatInt(t.Round(time.Millisecond).UnixNano(), 10)
 	case PrecisionSecond:
-		return fmt.Sprintf("%d", ptime.Round(time.Second).UnixNano())
+		return strconv.FormatInt(t.Round(time.Second).UnixNano(), 10)
 	case PrecisionMinute:
-		return fmt.Sprintf("%d", ptime.Round(time.Minute).UnixNano())
+		return strconv.FormatInt(t.Round(time.Minute).UnixNano(), 10)
 	case PrecisionHour:
-		return fmt.Sprintf("%d", ptime.Round(time.Hour).UnixNano())
+		return strconv.FormatInt(t.Round(time.Hour).UnixNano(), 10)
 	}
 	return ""
 }

--- a/opengemini/point_test.go
+++ b/opengemini/point_test.go
@@ -7,38 +7,62 @@ import (
 	"time"
 )
 
-func (p *Point) MarshalString() string {
+func encodePoint(p *Point) string {
 	var buf bytes.Buffer
 	enc := NewLineProtocolEncoder(&buf)
-	enc.Encode(p)
+	_ = enc.Encode(p)
 	return buf.String()
 }
 
-func TestPoint_String(t *testing.T) {
+func TestWriteString(t *testing.T) {
+	cases := []struct {
+		s, charsToEscape, result string
+	}{
+		{s: "foo", charsToEscape: "", result: "foo"},
+		{s: `f\\oo`, charsToEscape: "", result: `f\\\oo`},
+		{s: `\fo\o\`, charsToEscape: "", result: `\fo\o\`},
+		{s: `foo bar`, charsToEscape: " ", result: `foo\ bar`},
+		{s: `foo\ bar`, charsToEscape: " ", result: `foo\\\ bar`},
+		{s: `foo,\ bar`, charsToEscape: ", ", result: `foo\,\\\ bar`},
+		{s: `foo,\  bar`, charsToEscape: ", ", result: `foo\,\\\ \ bar`},
+		{s: `foo=,\  ba\r`, charsToEscape: ",= ", result: `foo\=\,\\\ \ ba\r`},
+	}
+
+	for _, c := range cases {
+		var buf bytes.Buffer
+		enc := NewLineProtocolEncoder(&buf)
+		_ = enc.writeString(c.s, c.charsToEscape)
+		if buf.String() != c.result {
+			t.Errorf("unexpected result: got %s, want %s", buf.String(), c.result)
+		}
+	}
+}
+
+func TestPointEncode(t *testing.T) {
 	point := &Point{}
-	// parse Point which hasn't set measurement
-	if strings.Compare(point.MarshalString(), "") != 0 {
+	// encode Point which hasn't set measurement
+	if strings.Compare(encodePoint(point), "") != 0 {
 		t.Error("error translate for point hasn't set measurement")
 	}
 	point.SetMeasurement("measurement")
-	// parse Point which hasn't own field
-	if strings.Compare(point.MarshalString(), "") != 0 {
+	// encode Point which hasn't own field
+	if strings.Compare(encodePoint(point), "") != 0 {
 		t.Error("error translate for point hasn't own field")
 	}
 	point.AddField("filed1", "string field")
-	// parse Point which only has a field
-	if strings.Compare(point.MarshalString(),
+	// encode Point which only has a field
+	if strings.Compare(encodePoint(point),
 		"measurement filed1=\"string field\"") != 0 {
 		t.Error("parse point with a string filed failed")
 	}
 	point.AddTag("tag", "tag1")
-	// parse Point which has a field with a tag
-	if strings.Compare(point.MarshalString(),
+	// encode Point which has a field with a tag
+	if strings.Compare(encodePoint(point),
 		"measurement,tag=tag1 filed1=\"string field\"") != 0 {
 		t.Error("parse point with a tag failed")
 	}
 	point.SetTime(time.Date(2023, 12, 1, 12, 32, 18, 132363612, time.UTC))
-	if strings.Compare(point.MarshalString(),
+	if strings.Compare(encodePoint(point),
 		"measurement,tag=tag1 filed1=\"string field\" 1701433938132363612") != 0 {
 		t.Error("parse point with a tag failed")
 	}

--- a/opengemini/point_test.go
+++ b/opengemini/point_test.go
@@ -1,42 +1,50 @@
 package opengemini
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 	"time"
 )
 
+func (p *Point) MarshalString() string {
+	var buf bytes.Buffer
+	enc := NewLineProtocolEncoder(&buf)
+	enc.Encode(p)
+	return buf.String()
+}
+
 func TestPoint_String(t *testing.T) {
 	point := &Point{}
 	// parse Point which hasn't set measurement
-	if strings.Compare(point.String(), "") != 0 {
+	if strings.Compare(point.MarshalString(), "") != 0 {
 		t.Error("error translate for point hasn't set measurement")
 	}
 	point.SetMeasurement("measurement")
 	// parse Point which hasn't own field
-	if strings.Compare(point.String(), "") != 0 {
+	if strings.Compare(point.MarshalString(), "") != 0 {
 		t.Error("error translate for point hasn't own field")
 	}
 	point.AddField("filed1", "string field")
 	// parse Point which only has a field
-	if strings.Compare(point.String(),
+	if strings.Compare(point.MarshalString(),
 		"measurement filed1=\"string field\"") != 0 {
 		t.Error("parse point with a string filed failed")
 	}
 	point.AddTag("tag", "tag1")
 	// parse Point which has a field with a tag
-	if strings.Compare(point.String(),
+	if strings.Compare(point.MarshalString(),
 		"measurement,tag=tag1 filed1=\"string field\"") != 0 {
 		t.Error("parse point with a tag failed")
 	}
 	point.SetTime(time.Date(2023, 12, 1, 12, 32, 18, 132363612, time.UTC))
-	if strings.Compare(point.String(),
+	if strings.Compare(point.MarshalString(),
 		"measurement,tag=tag1 filed1=\"string field\" 1701433938132363612") != 0 {
 		t.Error("parse point with a tag failed")
 	}
 }
 
-func TestParseTimestamp(t *testing.T) {
+func TestFormatTimestamp(t *testing.T) {
 	testTime := time.Date(2023, 12, 1, 12, 32, 18, 132363612, time.UTC)
 	tests := []struct {
 		precision PrecisionType
@@ -63,7 +71,7 @@ func TestParseTimestamp(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		if strings.Compare(parseTimestamp(tt.precision, testTime), tt.timestamp) != 0 {
+		if strings.Compare(formatTimestamp(testTime, tt.precision), tt.timestamp) != 0 {
 			t.Errorf("parse timestamp error in %v", tt.precision.String())
 		}
 	}

--- a/opengemini/write.go
+++ b/opengemini/write.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"sync/atomic"
 	"time"
 )
 
@@ -15,19 +14,13 @@ type WriteCallback func(error)
 
 func (c *client) WriteBatchPoints(database string, bp *BatchPoints) error {
 	var buffer bytes.Buffer
-	writer := c.newBuffer(&buffer)
+	writer := c.newWriter(&buffer)
 
-	for _, p := range bp.Points {
-		if p == nil {
-			continue
-		}
-		if _, err := io.WriteString(writer, p.String()); err != nil {
-			return err
-		}
-		if _, err := writer.Write([]byte{'\n'}); err != nil {
-			return err
-		}
+	enc := NewLineProtocolEncoder(writer)
+	if err := enc.BatchEncode(bp); err != nil {
+		return err
 	}
+
 	if closer, ok := writer.(io.Closer); ok {
 		if err := closer.Close(); err != nil {
 			return err
@@ -77,9 +70,10 @@ func (c *client) WritePoint(database string, point *Point, callback WriteCallbac
 	}
 
 	var buffer bytes.Buffer
-	writer := c.newBuffer(&buffer)
+	writer := c.newWriter(&buffer)
 
-	if _, err := io.WriteString(writer, point.String()); err != nil {
+	enc := NewLineProtocolEncoder(writer)
+	if err := enc.Encode(point); err != nil {
 		return err
 	}
 
@@ -114,24 +108,24 @@ func (c *client) internalBatchSend(database string, resource <-chan *sendBatchWi
 	var ticker = time.NewTicker(tickInterval)
 	var points = new(BatchPoints)
 	var cbs []WriteCallback
-	var needFlush atomic.Bool
+	needFlush := false
 	for {
 		select {
 		case <-c.ctx.Done():
 			ticker.Stop()
 			return
 		case <-ticker.C:
-			needFlush.Store(true)
+			needFlush = true
 		case record := <-resource:
 			points.AddPoint(record.point)
 			cbs = append(cbs, record.callback)
 		}
-		if len(points.Points) >= c.config.BatchConfig.BatchSize || needFlush.Load() {
+		if len(points.Points) >= c.config.BatchConfig.BatchSize || needFlush {
 			err := c.WriteBatchPoints(database, points)
 			for _, callback := range cbs {
 				callback(err)
 			}
-			needFlush.Store(false)
+			needFlush = false
 			ticker.Reset(tickInterval)
 			points.Points = []*Point{}
 			cbs = []WriteCallback{}
@@ -139,7 +133,7 @@ func (c *client) internalBatchSend(database string, resource <-chan *sendBatchWi
 	}
 }
 
-func (c *client) newBuffer(buffer *bytes.Buffer) io.Writer {
+func (c *client) newWriter(buffer *bytes.Buffer) io.Writer {
 	if c.config.GzipEnabled {
 		return gzip.NewWriter(buffer)
 	} else {


### PR DESCRIPTION
1. make point serialization in line with line protocol.
2. replace `fmt.Sprintf` with `strconv.FormatXXX` to improve performance.
3. avoid data copying to improve performance.
4. replace unnecessary atomic operations.
5. rename `parseXXXX` functions as `parse` is the opposite operation.