### PR TITLE
perf: optimize slice clearing operation

### DIFF
--- a/opengemini/write.go
+++ b/opengemini/write.go
@@ -129,8 +129,8 @@ func (c *client) internalBatchSend(ctx context.Context, database string, resourc
 			}
 			needFlush = false
 			ticker.Reset(tickInterval)
-			points = []*Point{}
-			cbs = []WriteCallback{}
+			points = points[:0]
+			cbs = cbs[:0]
 		}
 	}
 }


### PR DESCRIPTION
**Description**

This PR optimizes the initialization of slice a by replacing `a = []int{}` with `a = a[:0]`. This change reduces unnecessary memory allocation and improves performance.

**Motivation**

When a is initialized with `a = []int{}`, a new, empty slice is created, which allocates memory for the underlying array. However, if a is already allocated with a non-zero capacity, reslicing it with `a = a[:0]` reuses the existing underlying array, avoiding unnecessary memory allocation.

**Benefits**

1. Reduces memory allocation and garbage collection overhead
2. Improves performance by reusing existing memory allocation
3. Simplifies code by eliminating unnecessary memory allocation

**Notes**

This optimization is safe because it is a basic and ordinary optimization.
