### PR TITLE
fix: a panic error occurs in the func WritePoint when dbserver has been down #79

### DIFF
--- a/opengemini/write.go
+++ b/opengemini/write.go
@@ -87,7 +87,11 @@ func (c *client) WritePoint(ctx context.Context, database string, point *Point, 
 
 	resp, err := c.innerWrite(database, &buffer)
 	if err != nil {
-		callback(errors.New("innerWrite request failed, error: " + err.Error()))
+		err := errors.New("innerWrite request failed, error: " + err.Error())
+		if callback != nil {
+			callback(err)
+		}
+		return nil
 	}
 
 	defer resp.Body.Close()


### PR DESCRIPTION
This PR is to fix 2 problems:
1. It will panic in the func `WritePoint` when All DBServers are Down. The `resp` maybe nil when any Err ocurrs. 
2. It should check whether the `callback func ` is nil or not indeed. Just making func call using the `callback` directly doesn't seem friendly.It proves to be slightly confusing.