### PR TITLE
feat: make client does not register prometheus by default

### DIFF
--- a/opengemini/client.go
+++ b/opengemini/client.go
@@ -3,6 +3,7 @@ package opengemini
 import (
 	"context"
 	"crypto/tls"
+	"github.com/prometheus/client_golang/prometheus"
 	"time"
 )
 
@@ -52,6 +53,9 @@ type Client interface {
 
 	// Close shut down resources, such as health check tasks
 	Close() error
+
+	// ExposeMetrics expose prometheus metrics, calling prometheus.MustRegister(metrics) to register
+	ExposeMetrics() prometheus.Collector
 }
 
 // Config is used to construct a openGemini Client instance.

--- a/opengemini/metrics.go
+++ b/opengemini/metrics.go
@@ -113,6 +113,10 @@ func newMetricsProvider() *metrics {
 		}, labelNames),
 	}
 
-	prometheus.MustRegister(m)
 	return m
+}
+
+// ExposeMetrics expose prometheus metrics
+func (c *client) ExposeMetrics() prometheus.Collector {
+	return c.metrics
 }


### PR DESCRIPTION
client does not register prometheus by default, and exposes api on the Client