### PR TITLE
proposal: redefine show tag keys, tag values, field keys api

### DIFF
--- a/opengemini/client.go
+++ b/opengemini/client.go
@@ -70,12 +70,24 @@ type Client interface {
 	// forget to set the database and measurement otherwise it will return an error
 	DropMeasurement(database, retentionPolicy, measurement string) error
 
-	ShowTagKeys(database, command string) ([]ValuesResult, error)
-	ShowTagValues(database, command string) ([]ValuesResult, error)
-	ShowFieldKeys(database, command string) ([]ValuesResult, error)
+	// ShowTagKeys view all TAG fields in the measurements, return {"measurement_name":["TAG1","TAG2"]}
+	// calling `NewShowTagKeysBuilder().Database("db0").Measurement("m0")...` to setup builder, don't forget to set the
+	// database otherwise it will return an error, if retention policy is empty, use default retention policy `autogen`,
+	// if measurement is empty, show all measurements
+	ShowTagKeys(builder ShowTagKeysBuilder) (map[string][]string, error)
+	// ShowTagValues returns the tag value of the specified tag key in the database, return ["TAG1","TAG2"]
+	// calling `NewShowTagValuesBuilder().Database("db0").Measurement("m0")...` to setup builder, don't forget to set the
+	// database otherwise it will return an error, if retention policy is empty, use default retention policy `autogen`,
+	// if tag key is empty it will return an error
+	ShowTagValues(builder ShowTagValuesBuilder) ([]string, error)
+	// ShowFieldKeys get measurement schema, return {"measurement_name": {"field_name":"field_type"}}
+	// if measurement not exist, return all measurements in database, otherwise return the first measurement field keys
+	ShowFieldKeys(database string, measurements ...string) (map[string]map[string]string, error)
 	// ShowSeries returns the series of specified databases
-	// return [measurement1,tag1=value1 measurement2,tag2=value2]
-	ShowSeries(database, command string) ([]string, error)
+	// return [h2o_pH,location=coyote_creek h2o_pH,location=santa_monica h2o_feet,location=coyote_creek...]
+	// calling `NewShowSeriesBuilder().Database("db0")...` to setup builder, don't forget to set the database otherwise
+	// it will return an error
+	ShowSeries(builder ShowSeriesBuilder) ([]string, error)
 
 	// Close shut down resources, such as health check tasks
 	Close() error

--- a/opengemini/command.go
+++ b/opengemini/command.go
@@ -1,67 +1,175 @@
 package opengemini
 
-func (c *client) ShowTagKeys(database, command string) ([]ValuesResult, error) {
-	err := checkDatabaseAndCommand(database, command)
+import "fmt"
+
+func (c *client) ShowTagKeys(builder ShowTagKeysBuilder) (map[string][]string, error) {
+	command, err := builder.build()
+	if err != nil {
+		return nil, err
+	}
+	base := builder.getMeasurementBase()
+
+	queryResult, err := c.queryPost(Query{
+		Database:        base.database,
+		RetentionPolicy: base.retentionPolicy,
+		Command:         command,
+	})
+
 	if err != nil {
 		return nil, err
 	}
 
-	tagKeyResult, err := c.showTagSeriesQuery(database, command)
+	err = queryResult.hasError()
 	if err != nil {
-		return nil, err
-	}
-	return tagKeyResult, nil
-}
-
-func (c *client) ShowTagValues(database, command string) ([]ValuesResult, error) {
-	err := checkDatabaseAndCommand(database, command)
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("show tag keys err: %s", err)
 	}
 
-	tagValueResult, err := c.showTagFieldQuery(database, command)
-	if err != nil {
-		return nil, err
+	var data = make(map[string][]string)
+	if len(queryResult.Results) == 0 {
+		return data, nil
 	}
-	return tagValueResult, nil
-}
-
-func (c *client) ShowFieldKeys(database, command string) ([]ValuesResult, error) {
-	err := checkDatabaseAndCommand(database, command)
-	if err != nil {
-		return nil, err
-	}
-
-	tagKeyResult, err := c.showTagFieldQuery(database, command)
-	if err != nil {
-		return nil, err
-	}
-	return tagKeyResult, nil
-}
-
-func (c *client) ShowSeries(database, command string) ([]string, error) {
-	err := checkDatabaseAndCommand(database, command)
-	if err != nil {
-		return nil, err
-	}
-
-	seriesResult, err := c.showTagSeriesQuery(database, command)
-	if err != nil {
-		return nil, err
-	}
-	if len(seriesResult) == 0 {
-		return []string{}, nil
-	}
-	var (
-		values = seriesResult[0].Values
-		series = make([]string, 0, len(values))
-	)
-	for _, v := range values {
-		strV, ok := v.(string)
-		if !ok {
-			return series, nil
+	for _, series := range queryResult.Results[0].Series {
+		var tags []string
+		for _, values := range series.Values {
+			for _, value := range values {
+				strVal, ok := value.(string)
+				if !ok {
+					continue
+				}
+				tags = append(tags, strVal)
+			}
 		}
-		series = append(series, strV)
+		data[series.Name] = tags
 	}
-	return series, nil
+
+	return data, nil
+}
+
+func (c *client) ShowTagValues(builder ShowTagValuesBuilder) ([]string, error) {
+	command, err := builder.build()
+	if err != nil {
+		return nil, err
+	}
+	base := builder.getMeasurementBase()
+
+	queryResult, err := c.queryPost(Query{
+		Database:        base.database,
+		RetentionPolicy: base.retentionPolicy,
+		Command:         command,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = queryResult.hasError()
+	if err != nil {
+		return nil, fmt.Errorf("show tag value err: %s", err)
+	}
+
+	var values []string
+	if len(queryResult.Results) == 0 {
+		return values, nil
+	}
+
+	querySeries := queryResult.Results[0].Series
+	for _, series := range querySeries {
+		for _, valRes := range series.Values {
+			if len(valRes) != 2 {
+				return []string{}, fmt.Errorf("invalid values: %s", valRes)
+			}
+			if strVal, ok := valRes[1].(string); ok {
+				values = append(values, strVal)
+			}
+		}
+	}
+
+	return values, nil
+}
+
+func (c *client) ShowFieldKeys(database string, measurements ...string) (map[string]map[string]string, error) {
+	var measurement string
+	if len(measurements) != 0 {
+		measurement = measurements[0]
+	}
+	err := checkDatabaseName(database)
+	if err != nil {
+		return nil, err
+	}
+
+	var command = "SHOW FIELD KEYS"
+	if measurement != "" {
+		command += " FROM " + measurement
+	}
+
+	queryResult, err := c.Query(Query{Database: database, Command: command})
+	if err != nil {
+		return nil, err
+	}
+
+	if queryResult.hasError() != nil {
+		return nil, queryResult.hasError()
+	}
+
+	if len(queryResult.Results) == 0 {
+		return nil, nil
+	}
+
+	querySeries := queryResult.Results[0].Series
+	var value = make(map[string]map[string]string, len(querySeries))
+
+	for _, series := range querySeries {
+		var kv = make(map[string]string, len(series.Values))
+		for _, valRes := range series.Values {
+			if len(valRes) != 2 {
+				return nil, fmt.Errorf("invalid values: %s", valRes)
+			}
+			var k, v string
+			if strVal, ok := valRes[0].(string); ok {
+				k = strVal
+			}
+			if strVal, ok := valRes[1].(string); ok {
+				v = strVal
+			}
+			kv[k] = v
+		}
+		value[series.Name] = kv
+	}
+	return value, nil
+}
+
+func (c *client) ShowSeries(builder ShowSeriesBuilder) ([]string, error) {
+	command, err := builder.build()
+	if err != nil {
+		return nil, err
+	}
+
+	base := builder.getMeasurementBase()
+
+	seriesResult, err := c.Query(Query{Database: base.database, RetentionPolicy: base.retentionPolicy, Command: command})
+	if err != nil {
+		return nil, err
+	}
+
+	err = seriesResult.hasError()
+	if err != nil {
+		return nil, fmt.Errorf("get series failed: %s", err)
+	}
+
+	var seriesValues = make([]string, 0, len(seriesResult.Results))
+	if len(seriesResult.Results) == 0 {
+		return seriesValues, nil
+	}
+	for _, series := range seriesResult.Results[0].Series {
+		for _, values := range series.Values {
+			for _, value := range values {
+				strVal, ok := value.(string)
+				if !ok {
+					continue
+				}
+				seriesValues = append(seriesValues, strVal)
+			}
+		}
+	}
+	return seriesValues, nil
 }

--- a/opengemini/command_test.go
+++ b/opengemini/command_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sort"
 	"testing"
+	"time"
 )
 
 func TestClientShowTagKeys(t *testing.T) {
@@ -16,12 +18,60 @@ func TestClientShowTagKeys(t *testing.T) {
 	cmd := fmt.Sprintf("CREATE MEASUREMENT %s (tag1 TAG,tag2 TAG,tag3 TAG, field1 INT64 FIELD, field2 BOOL, field3 STRING, field4 FLOAT64)", measurement)
 	_, err = c.Query(Query{Command: cmd, Database: databaseName})
 	assert.Nil(t, err)
-	showKeyCmd := fmt.Sprintf("SHOW TAG KEYS FROM %s limit 3 OFFSET 0", measurement)
-	tagKeyResult, err := c.ShowTagKeys(databaseName, showKeyCmd)
+	// SHOW TAG KEYS FROM measurement limit 3 OFFSET 0
+	tagKeyResult, err := c.ShowTagKeys(NewShowTagKeysBuilder().Database(databaseName).Measurement(measurement).Limit(3).Offset(0))
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(tagKeyResult))
+	assert.Equal(t, 3, len(tagKeyResult[measurement]))
 	err = c.DropDatabase(databaseName)
 	require.Nil(t, err)
+}
+
+func TestClientShowTagKeys_WithOffset(t *testing.T) {
+	c := testDefaultClient(t)
+	databaseName := randomDatabaseName()
+	err := c.CreateDatabase(databaseName)
+	require.Nil(t, err)
+	measurement := randomMeasurement()
+	cmd := fmt.Sprintf("CREATE MEASUREMENT %s (tag1 TAG,tag2 TAG,tag3 TAG, field1 INT64 FIELD, field2 BOOL, field3 STRING, field4 FLOAT64)", measurement)
+	_, err = c.Query(Query{Command: cmd, Database: databaseName})
+	assert.Nil(t, err)
+	// SHOW TAG KEYS FROM measurement limit 3 OFFSET 0
+	tagKeyResult, err := c.ShowTagKeys(NewShowTagKeysBuilder().Database(databaseName).Measurement(measurement).Limit(0).Offset(1))
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(tagKeyResult))
+	// skip tag1, so value is []string{"tag2", "tag3"}
+	assert.Equal(t, 2, len(tagKeyResult[measurement]))
+	err = c.DropDatabase(databaseName)
+	require.Nil(t, err)
+}
+
+func TestClientShowTagKeys_WithLimit(t *testing.T) {
+	c := testDefaultClient(t)
+	databaseName := randomDatabaseName()
+	err := c.CreateDatabase(databaseName)
+	require.Nil(t, err)
+	measurement := randomMeasurement()
+	cmd := fmt.Sprintf("CREATE MEASUREMENT %s (tag1 TAG,tag2 TAG,tag3 TAG, field1 INT64 FIELD, field2 BOOL, field3 STRING, field4 FLOAT64)", measurement)
+	_, err = c.Query(Query{Command: cmd, Database: databaseName})
+	assert.Nil(t, err)
+	// SHOW TAG KEYS FROM measurement limit 3 OFFSET 0
+	tagKeyResult, err := c.ShowTagKeys(NewShowTagKeysBuilder().Database(databaseName).Measurement(measurement).Limit(1).Offset(1))
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(tagKeyResult))
+	// offset 1 and skip tag1, so value is []string{"tag2"}
+	assert.Equal(t, 1, len(tagKeyResult[measurement]))
+	assert.Equal(t, "tag2", tagKeyResult[measurement][0])
+	err = c.DropDatabase(databaseName)
+	require.Nil(t, err)
+}
+
+func TestClientShowTagKeys_Error_NoDatabase(t *testing.T) {
+	c := testDefaultClient(t)
+	measurement := randomMeasurement()
+	tagKeyResult, err := c.ShowTagKeys(NewShowTagKeysBuilder().Database("").Measurement(measurement).Limit(3).Offset(0))
+	assert.Error(t, err)
+	assert.Nil(t, tagKeyResult)
 }
 
 func TestClient_ShowFieldKeys(t *testing.T) {
@@ -33,9 +83,412 @@ func TestClient_ShowFieldKeys(t *testing.T) {
 	cmd := fmt.Sprintf("CREATE MEASUREMENT %s (tag1 TAG,tag2 TAG,tag3 TAG, field1 INT64 FIELD, field2 BOOL, field3 STRING, field4 FLOAT64)", measurement)
 	_, err = c.Query(Query{Command: cmd, Database: databaseName})
 	assert.Nil(t, err)
-	tagFieldResult, err := c.ShowFieldKeys(databaseName, fmt.Sprintf("SHOW FIELD KEYS FROM %s", measurement))
+	tagFieldResult, err := c.ShowFieldKeys(databaseName, measurement)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(tagFieldResult))
+	// TODO return value is different with create command, confirm the reason with the community
+	assert.EqualValues(t, "integer", tagFieldResult[measurement]["field1"])
+	assert.EqualValues(t, "boolean", tagFieldResult[measurement]["field2"])
+	assert.EqualValues(t, "string", tagFieldResult[measurement]["field3"])
+	assert.EqualValues(t, "float", tagFieldResult[measurement]["field4"])
 	err = c.DropDatabase(databaseName)
 	require.Nil(t, err)
+}
+
+func TestClient_ShowTagValues(t *testing.T) {
+	c := testDefaultClient(t)
+	databaseName := randomDatabaseName()
+	err := c.CreateDatabase(databaseName)
+	require.Nil(t, err)
+	measurement := randomMeasurement()
+	defer func() {
+		err := c.DropDatabase(databaseName)
+		assert.Nil(t, err)
+	}()
+	callback := func(err error) {
+		assert.Nil(t, err)
+	}
+
+	points := []*Point{
+		{
+			Measurement: measurement,
+			Tags: map[string]string{
+				"location": "c1",
+				"country":  "cn",
+			},
+			Fields: map[string]interface{}{
+				"weather":     "sun",
+				"temperature": 25.0,
+			},
+		},
+		{
+			Measurement: measurement,
+			Tags: map[string]string{
+				"location": "c2",
+				"country":  "cn",
+			},
+			Fields: map[string]interface{}{
+				"weather":     "sun",
+				"temperature": 26.0,
+			},
+		},
+		{
+			Measurement: measurement,
+			Tags: map[string]string{
+				"location": "u1",
+				"country":  "us",
+			},
+			Fields: map[string]interface{}{
+				"weather":     "sun",
+				"temperature": 35.0,
+			},
+		},
+		{
+			Measurement: measurement,
+			Tags: map[string]string{
+				"location": "u2",
+				"country":  "us",
+			},
+			Fields: map[string]interface{}{
+				"weather":     "sun",
+				"temperature": 36.0,
+			},
+		},
+	}
+
+	for _, point := range points {
+		err := c.WritePoint(databaseName, point, callback)
+		assert.Nil(t, err)
+	}
+	time.Sleep(time.Second * 5)
+
+	// SHOW TAG VALUES FROM measurement WITH KEY = location
+	tagValueResult, err := c.ShowTagValues(NewShowTagValuesBuilder().Database(databaseName).Measurement(measurement).
+		With("location"))
+	assert.Nil(t, err)
+	assert.Equal(t, 4, len(tagValueResult))
+	expValues := []string{"c1", "c2", "u1", "u2"}
+	sort.Strings(expValues)
+	sort.Strings(tagValueResult)
+	assert.EqualValues(t, expValues, tagValueResult)
+
+	// SHOW TAG VALUES FROM measurement WITH KEY = location LIMIT 2 OFFSET 0
+	tagValueResult, err = c.ShowTagValues(NewShowTagValuesBuilder().Database(databaseName).Measurement(measurement).
+		With("location").Limit(2).Offset(0))
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(tagValueResult))
+	expValues = []string{"c1", "c2"}
+	sort.Strings(expValues)
+	sort.Strings(tagValueResult)
+	assert.EqualValues(t, expValues, tagValueResult)
+
+	// SHOW TAG VALUES FROM measurement WITH KEY = location LIMIT 2 OFFSET 2
+	tagValueResult, err = c.ShowTagValues(NewShowTagValuesBuilder().Database(databaseName).Measurement(measurement).
+		With("location").Limit(2).Offset(2))
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(tagValueResult))
+	expValues = []string{"u1", "u2"}
+	sort.Strings(expValues)
+	sort.Strings(tagValueResult)
+	assert.EqualValues(t, expValues, tagValueResult)
+
+	// SHOW TAG VALUES FROM measurement WITH KEY = location LIMIT 2 OFFSET 2 WHERE country = cn
+	tagValueResult, err = c.ShowTagValues(NewShowTagValuesBuilder().Database(databaseName).Measurement(measurement).
+		With("location").Limit(2).Offset(2).Where("country", Equals, "cn"))
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(tagValueResult))
+}
+
+func TestClient_ShowTagValues_WithRegexp(t *testing.T) {
+	c := testDefaultClient(t)
+	databaseName := randomDatabaseName()
+	err := c.CreateDatabase(databaseName)
+	require.Nil(t, err)
+	measurement := randomMeasurement()
+	defer func() {
+		err := c.DropDatabase(databaseName)
+		assert.Nil(t, err)
+	}()
+	callback := func(err error) {
+		assert.Nil(t, err)
+	}
+
+	points := []*Point{
+		{
+			Measurement: measurement,
+			Tags: map[string]string{
+				"location": "c1",
+				"country":  "cn",
+			},
+			Fields: map[string]interface{}{
+				"weather":     "sun",
+				"temperature": 25.0,
+			},
+		},
+		{
+			Measurement: measurement,
+			Tags: map[string]string{
+				"location": "c2",
+				"country":  "cn",
+			},
+			Fields: map[string]interface{}{
+				"weather":     "sun",
+				"temperature": 26.0,
+			},
+		},
+		{
+			Measurement: measurement,
+			Tags: map[string]string{
+				"location": "u1",
+				"country":  "us",
+			},
+			Fields: map[string]interface{}{
+				"weather":     "sun",
+				"temperature": 35.0,
+			},
+		},
+		{
+			Measurement: measurement,
+			Tags: map[string]string{
+				"location": "u2",
+				"country":  "us",
+			},
+			Fields: map[string]interface{}{
+				"weather":     "sun",
+				"temperature": 36.0,
+			},
+		},
+	}
+
+	for _, point := range points {
+		err := c.WritePoint(databaseName, point, callback)
+		assert.Nil(t, err)
+	}
+	time.Sleep(time.Second * 5)
+
+	// SHOW TAG VALUES FROM measurement WITH KEY = /loc.*/
+	tagValueResult, err := c.ShowTagValues(NewShowTagValuesBuilder().Database(databaseName).Measurement(measurement).
+		With("/loc.*/"))
+	assert.Nil(t, err)
+	assert.Equal(t, 4, len(tagValueResult))
+	expValues := []string{"c1", "c2", "u1", "u2"}
+	sort.Strings(expValues)
+	sort.Strings(tagValueResult)
+	assert.EqualValues(t, expValues, tagValueResult)
+
+	// SHOW TAG VALUES FROM measurement WITH KEY = /loc./ LIMIT 2 OFFSET 0
+	tagValueResult, err = c.ShowTagValues(NewShowTagValuesBuilder().Database(databaseName).Measurement(measurement).
+		With("/loc.*/").Limit(2).Offset(0))
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(tagValueResult))
+	expValues = []string{"c1", "c2"}
+	sort.Strings(expValues)
+	sort.Strings(tagValueResult)
+	assert.EqualValues(t, expValues, tagValueResult)
+
+	// SHOW TAG VALUES FROM measurement WITH KEY = /loc./ LIMIT 2 OFFSET 2
+	tagValueResult, err = c.ShowTagValues(NewShowTagValuesBuilder().Database(databaseName).Measurement(measurement).
+		With("/loc.*/").Limit(2).Offset(2))
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(tagValueResult))
+	expValues = []string{"u1", "u2"}
+	sort.Strings(expValues)
+	sort.Strings(tagValueResult)
+	assert.EqualValues(t, expValues, tagValueResult)
+
+	// SHOW TAG VALUES FROM measurement WITH KEY = /loc./ LIMIT 2 OFFSET 2 WHERE country = cn
+	tagValueResult, err = c.ShowTagValues(NewShowTagValuesBuilder().Database(databaseName).Measurement(measurement).
+		With("/loc.*/").Limit(2).Offset(2).Where("country", Equals, "cn"))
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(tagValueResult))
+}
+
+func TestClient_ShowTagValues_WithIn(t *testing.T) {
+	c := testDefaultClient(t)
+	databaseName := randomDatabaseName()
+	err := c.CreateDatabase(databaseName)
+	require.Nil(t, err)
+	measurement := randomMeasurement()
+	defer func() {
+		err := c.DropDatabase(databaseName)
+		assert.Nil(t, err)
+	}()
+	callback := func(err error) {
+		assert.Nil(t, err)
+	}
+
+	points := []*Point{
+		{
+			Measurement: measurement,
+			Tags: map[string]string{
+				"location": "c1",
+				"country":  "cn",
+			},
+			Fields: map[string]interface{}{
+				"weather":     "sun",
+				"temperature": 25.0,
+			},
+		},
+		{
+			Measurement: measurement,
+			Tags: map[string]string{
+				"location": "c2",
+				"country":  "cn",
+			},
+			Fields: map[string]interface{}{
+				"weather":     "sun",
+				"temperature": 26.0,
+			},
+		},
+		{
+			Measurement: measurement,
+			Tags: map[string]string{
+				"location": "u1",
+				"country":  "us",
+			},
+			Fields: map[string]interface{}{
+				"weather":     "sun",
+				"temperature": 35.0,
+			},
+		},
+		{
+			Measurement: measurement,
+			Tags: map[string]string{
+				"location": "u2",
+				"country":  "us",
+			},
+			Fields: map[string]interface{}{
+				"weather":     "sun",
+				"temperature": 36.0,
+			},
+		},
+	}
+
+	for _, point := range points {
+		err := c.WritePoint(databaseName, point, callback)
+		assert.Nil(t, err)
+	}
+	time.Sleep(time.Second * 5)
+
+	// SHOW TAG VALUES FROM measurement WITH KEY IN (location, country)
+	tagValueResult, err := c.ShowTagValues(NewShowTagValuesBuilder().Database(databaseName).Measurement(measurement).
+		With("location", "country"))
+	assert.Nil(t, err)
+	assert.Equal(t, 6, len(tagValueResult))
+	expValues := []string{"c1", "c2", "u1", "u2", "cn", "us"}
+	sort.Strings(expValues)
+	sort.Strings(tagValueResult)
+	assert.EqualValues(t, expValues, tagValueResult)
+
+	// SHOW TAG VALUES FROM measurement WITH KEY IN (location, country) LIMIT 2 OFFSET 0
+	tagValueResult, err = c.ShowTagValues(NewShowTagValuesBuilder().Database(databaseName).Measurement(measurement).
+		With("location", "country").Limit(2).Offset(0))
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(tagValueResult))
+
+	// SHOW TAG VALUES FROM measurement WITH KEY IN (location, country) LIMIT 2 OFFSET 2
+	tagValueResult, err = c.ShowTagValues(NewShowTagValuesBuilder().Database(databaseName).Measurement(measurement).
+		With("location", "country").Limit(2).Offset(2))
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(tagValueResult))
+
+	// SHOW TAG VALUES FROM measurement WITH KEY IN (location, country) LIMIT 2 OFFSET 2 WHERE country = cn
+	_, err = c.ShowTagValues(NewShowTagValuesBuilder().Database(databaseName).Measurement(measurement).
+		With("location", "country").Limit(2).Offset(2).Where("country", Equals, "cn"))
+	assert.Nil(t, err)
+}
+
+func TestClient_ShowTagValues_Error_NoWithKey(t *testing.T) {
+	c := testDefaultClient(t)
+	_, err := c.ShowTagValues(NewShowTagValuesBuilder().Database("not-exist-db").
+		Measurement("not-exist-measurement"))
+	assert.NotNil(t, err)
+	assert.Equal(t, ErrEmptyTagKey, err)
+}
+
+func TestClient_ShowSeries(t *testing.T) {
+	c := testDefaultClient(t)
+	databaseName := randomDatabaseName()
+	err := c.CreateDatabase(databaseName)
+	require.Nil(t, err)
+	measurement := randomMeasurement()
+	defer func() {
+		err := c.DropDatabase(databaseName)
+		assert.Nil(t, err)
+	}()
+	callback := func(err error) {
+		assert.Nil(t, err)
+	}
+
+	points := []*Point{
+		{
+			Measurement: measurement,
+			Tags: map[string]string{
+				"vector1": "v1",
+				"horizon": "h1",
+			},
+			Fields: map[string]interface{}{
+				"temperature": 25.0,
+			},
+		},
+		{
+			Measurement: measurement,
+			Tags: map[string]string{
+				"vector2": "c2",
+				"country": "cn",
+			},
+			Fields: map[string]interface{}{
+				"vector3":     "sun",
+				"temperature": 26.0,
+			},
+		},
+		{
+			Measurement: measurement,
+			Tags: map[string]string{
+				"vector3": "u1",
+				"country": "us",
+			},
+			Fields: map[string]interface{}{
+				"weather":     "sun",
+				"temperature": 35.0,
+			},
+		},
+		{
+			Measurement: measurement,
+			Tags: map[string]string{
+				"vector4": "u2",
+				"country": "us",
+			},
+			Fields: map[string]interface{}{
+				"weather":     "sun",
+				"temperature": 36.0,
+			},
+		},
+	}
+
+	for _, point := range points {
+		err := c.WritePoint(databaseName, point, callback)
+		assert.Nil(t, err)
+	}
+	time.Sleep(time.Second * 5)
+
+	// SHOW SERIES FROM measurement
+	seriesResult, err := c.ShowSeries(NewShowSeriesBuilder().Database(databaseName).Measurement(measurement))
+	assert.Nil(t, err)
+	assert.Equal(t, 4, len(seriesResult))
+
+	// SHOW SERIES FROM measurement LIMIT 2 OFFSET 0
+	seriesResult, err = c.ShowSeries(NewShowSeriesBuilder().Database(databaseName).Measurement(measurement).Limit(2).Offset(0))
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(seriesResult))
+
+	// SHOW SERIES FROM measurement LIMIT 2 OFFSET 2
+	seriesResult, err = c.ShowSeries(NewShowSeriesBuilder().Database(databaseName).Measurement(measurement).Limit(2).Offset(2))
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(seriesResult))
+
+	// SHOW SERIES FROM measurement WHERE country = cn
+	seriesResult, err = c.ShowSeries(NewShowSeriesBuilder().Database(databaseName).Measurement(measurement).Where("country", Equals, "cn"))
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(seriesResult))
 }

--- a/opengemini/error.go
+++ b/opengemini/error.go
@@ -8,6 +8,7 @@ var (
 	ErrEmptyMeasurement  = errors.New("empty measurement")
 	ErrEmptyCommand      = errors.New("empty command")
 	ErrEmptyTagOrField   = errors.New("empty tag or field")
+	ErrEmptyTagKey       = errors.New("empty tag key")
 )
 
 // checkDatabaseName checks if the database name is empty and returns an error if it is.
@@ -32,17 +33,6 @@ func checkDatabaseAndPolicy(database, retentionPolicy string) error {
 	}
 	if len(retentionPolicy) == 0 {
 		return ErrRetentionPolicy
-	}
-	return nil
-}
-
-// checkDatabaseAndCommand checks if the database name or command is empty and returns an appropriate error.
-func checkDatabaseAndCommand(database, command string) error {
-	if len(database) == 0 {
-		return ErrEmptyDatabaseName
-	}
-	if len(command) == 0 {
-		return ErrEmptyCommand
 	}
 	return nil
 }

--- a/opengemini/write_test.go
+++ b/opengemini/write_test.go
@@ -2,7 +2,6 @@ package opengemini
 
 import (
 	"context"
-	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -231,13 +230,11 @@ func TestWriteAssignedIntegerField(t *testing.T) {
 	time.Sleep(time.Second * 5)
 
 	// check field's data type
-	res, err := c.ShowFieldKeys(database, fmt.Sprintf("SHOW FIELD KEYS FROM %s", measurement))
+	res, err := c.ShowFieldKeys(database, measurement)
 	assert.Nil(t, err)
-	if value, ok := res[0].Values[0].(keyValue); !ok {
-		t.Fail()
-	} else {
-		assert.Equal(t, "integer", value.Value)
-	}
+	fields, ok := res[measurement]
+	assert.True(t, ok)
+	assert.EqualValues(t, "integer", fields["field"])
 }
 
 func TestWriteWithBatchInterval(t *testing.T) {


### PR DESCRIPTION
In order to better understand and use APIs, we should have clear and simple API usage tutorials and tools to help users build their own applications. However, so far, the instructions for using the APIs `ShowTagKeys`, `ShowTagValues`, and `ShowFieldKeys` are vague, and users have no idea how to use the APIs. We need to inform users how to generate the command parameters of each API and what the return value means.

I have temporarily written comments for these APIs and created their builders to quickly generate simple query SQL.