### PR TITLE
refactor: remove context param from WritePoint method

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ point.Measurement = exampleMeasurement
 point.AddTag("Weather", "foggy")
 point.AddField("Humidity", 87)
 point.AddField("Temperature", 25)
-err = client.WritePoint(context.Background(),exampleDatabase, point, func(err error) {
+err = client.WritePoint(exampleDatabase, point, func(err error) {
 	if err != nil {
 		fmt.Printf("write point failed for %s", err)
 	}

--- a/README_CN.md
+++ b/README_CN.md
@@ -65,7 +65,7 @@ point.Measurement = exampleMeasurement
 point.AddTag("Weather", "foggy")
 point.AddField("Humidity", 87)
 point.AddField("Temperature", 25)
-err = client.WritePoint(context.Background(),exampleDatabase, point, func(err error) {
+err = client.WritePoint(exampleDatabase, point, func(err error) {
 	if err != nil {
 		fmt.Printf("write point failed for %s", err)
 	}

--- a/examples/example/example.go
+++ b/examples/example/example.go
@@ -5,7 +5,6 @@ package main
 */
 
 import (
-	"context"
 	"fmt"
 	. "github.com/openGemini/opengemini-client-go/opengemini"
 	"math/rand"
@@ -42,7 +41,7 @@ func main() {
 	point.AddTag("Weather", "foggy")
 	point.AddField("Humidity", 87)
 	point.AddField("Temperature", 25)
-	err = client.WritePoint(context.Background(), exampleDatabase, point, func(err error) {
+	err = client.WritePoint(exampleDatabase, point, func(err error) {
 		if err != nil {
 			fmt.Printf("write point failed for %s", err)
 		}

--- a/opengemini/client.go
+++ b/opengemini/client.go
@@ -1,7 +1,6 @@
 package opengemini
 
 import (
-	"context"
 	"crypto/tls"
 	"github.com/prometheus/client_golang/prometheus"
 	"time"
@@ -22,10 +21,10 @@ type Client interface {
 
 	// WritePoint write single point to assigned database. If you don't want to implement callbackFunc to receive error
 	// in writing, you cloud use opengemini.CallbackDummy.
-	WritePoint(ctx context.Context, database string, point *Point, callbackFunc WriteCallback) error
+	WritePoint(database string, point *Point, callbackFunc WriteCallback) error
 	// WritePointWithRp write single point with retention policy. If you don't want to implement callbackFunc to
 	//  receive error in writing, you cloud use opengemini.CallbackDummy.
-	WritePointWithRp(ctx context.Context, database string, rp string, point *Point, callbackFunc WriteCallback) error
+	WritePointWithRp(database string, rp string, point *Point, callbackFunc WriteCallback) error
 	// WriteBatchPoints write batch points to assigned database
 	WriteBatchPoints(database string, bp []*Point) error
 	// WriteBatchPointsWithRp write batch points with retention policy

--- a/opengemini/query_test.go
+++ b/opengemini/query_test.go
@@ -1,7 +1,6 @@
 package opengemini
 
 import (
-	"context"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
@@ -27,7 +26,7 @@ func TestQueryWithEpoch(t *testing.T) {
 	p.AddField("TestField", 123)
 	p.Time = time.Now()
 
-	err = c.WritePoint(context.Background(), database, p, func(err error) {
+	err = c.WritePoint(database, p, func(err error) {
 		assert.Nil(t, err)
 	})
 	assert.Nil(t, err)

--- a/opengemini/write_test.go
+++ b/opengemini/write_test.go
@@ -1,7 +1,6 @@
 package opengemini
 
 import (
-	"context"
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -149,7 +148,7 @@ func TestClientWritePoint(t *testing.T) {
 	point.Measurement = randomMeasurement()
 	point.AddTag("tag", "test")
 	point.AddField("field", "test")
-	err = c.WritePoint(context.Background(), database, point, callback)
+	err = c.WritePoint(database, point, callback)
 	assert.Nil(t, err)
 }
 
@@ -176,7 +175,7 @@ func TestClientWritePointWithRetentionPolicy(t *testing.T) {
 	point.Measurement = randomMeasurement()
 	point.AddTag("tag", "test")
 	point.AddField("field", "test")
-	err = c.WritePointWithRp(context.Background(), database, "testRp", point, callback)
+	err = c.WritePointWithRp(database, "testRp", point, callback)
 	assert.Nil(t, err)
 	time.Sleep(time.Second * 3)
 	res, err := c.Query(Query{
@@ -217,7 +216,7 @@ func TestWriteAssignedIntegerField(t *testing.T) {
 	point.Measurement = measurement
 	point.AddTag("tag", "test")
 	point.AddField("field", 123)
-	err = c.WritePoint(context.Background(), database, point, callback)
+	err = c.WritePoint(database, point, callback)
 	assert.Nil(t, err)
 
 	time.Sleep(time.Second * 5)
@@ -261,7 +260,7 @@ func TestWriteWithBatchInterval(t *testing.T) {
 	point.AddField("field", "interval")
 	receiver := make(chan struct{})
 	startTime := time.Now()
-	err = c.WritePoint(context.Background(), database, point, func(err error) {
+	err = c.WritePoint(database, point, func(err error) {
 		receiver <- struct{}{}
 	})
 	assert.Nil(t, err)
@@ -308,7 +307,7 @@ func TestWriteWithBatchSize(t *testing.T) {
 		point.Measurement = "test"
 		point.AddField("field", "test")
 		point.Time = time.Now()
-		err := c.WritePoint(context.Background(), database, point, func(err error) {
+		err := c.WritePoint(database, point, func(err error) {
 			receiver <- struct{}{}
 		})
 		assert.Nil(t, err)


### PR DESCRIPTION
Golang doesn't support merge context. In our implement, multi **WritePoint** request will be merged in to one http call. So I propose remove it 
See more in https://github.com/golang/go/issues/36503