### PR TITLE
feat: add custom labels to all the metrics

### DIFF
--- a/examples/multiple-clients/main.go
+++ b/examples/multiple-clients/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"github.com/openGemini/opengemini-client-go/opengemini"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"net/http"
+)
+
+func main() {
+	// create an openGemini client
+	configA := &opengemini.Config{
+		Addresses: []*opengemini.Address{{
+			Host: "127.0.0.1",
+			Port: 8086,
+		}},
+		CustomMetricsLabels: map[string]string{
+			"instance": "client-a",
+		},
+	}
+	clientA, err := opengemini.NewClient(configA)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	configB := &opengemini.Config{
+		Addresses: []*opengemini.Address{{
+			Host: "127.0.0.1",
+			Port: 8086,
+		}},
+		CustomMetricsLabels: map[string]string{
+			"instance": "client-b",
+		},
+	}
+	clientB, err := opengemini.NewClient(configB)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	prometheus.MustRegister(clientA.ExposeMetrics(), clientB.ExposeMetrics())
+
+	http.Handle("/metrics", promhttp.Handler())
+	http.ListenAndServe(":8089", nil)
+}

--- a/opengemini/client.go
+++ b/opengemini/client.go
@@ -85,6 +85,8 @@ type Config struct {
 	TlsEnabled bool
 	// TlsConfig configuration information for tls.
 	TlsConfig *tls.Config
+	// CustomMetricsLabels add custom labels to all the metrics reported by this client instance
+	CustomMetricsLabels map[string]string
 }
 
 // Address configuration for providing service.

--- a/opengemini/client_impl.go
+++ b/opengemini/client_impl.go
@@ -64,7 +64,7 @@ func newClient(c *Config) (Client, error) {
 		config:             c,
 		endpoints:          buildEndpoints(c.Addresses, c.TlsEnabled),
 		cli:                newHttpClient(*c),
-		metrics:            newMetricsProvider(),
+		metrics:            newMetricsProvider(c.CustomMetricsLabels),
 		batchContext:       ctx,
 		batchContextCancel: cancel,
 	}

--- a/opengemini/metrics.go
+++ b/opengemini/metrics.go
@@ -43,10 +43,14 @@ func (m *metrics) Collect(ch chan<- prometheus.Metric) {
 }
 
 // newMetricsProvider returns metrics registered to registerer.
-func newMetricsProvider() *metrics {
+func newMetricsProvider(customLabels map[string]string) *metrics {
 	constLabels := map[string]string{
 		"client": "go", // distinguish from other language client
 	}
+	for k, v := range customLabels {
+		constLabels[k] = v
+	}
+
 	constQuantiles := map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001}
 	labelNames := []string{"database"}
 


### PR DESCRIPTION
Provides a `CustomMetricsLabels` option for the client, add custom labels to all the metrics reported by this client instance.

Close: #135 