### PR TITLE
feat: porting kernel record module to internal

### DIFF
--- a/.github/workflows/license_lint.yml
+++ b/.github/workflows/license_lint.yml
@@ -23,8 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: skip generated files
-        run: rm -rf proto/*.pb.go
+      - name: skip generated files and dot folders
+        run: rm -rf proto/*.pb.go && rm -rf .idea
       - name: licenselint
         uses: shoothzj/licenselint@main
         with:

--- a/internal/record/column_boolean.go
+++ b/internal/record/column_boolean.go
@@ -1,0 +1,31 @@
+// Copyright 2024 openGemini Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record
+
+func (cv *ColVal) AppendBooleanNull() {
+	appendNull(cv)
+}
+
+func (cv *ColVal) AppendBooleanNulls(count int) {
+	appendNulls(cv, count)
+}
+
+func (cv *ColVal) AppendBooleans(values ...bool) {
+	appendValues(cv, values...)
+}
+
+func (cv *ColVal) AppendBoolean(v bool) {
+	appendValue(cv, v)
+}

--- a/internal/record/column_float.go
+++ b/internal/record/column_float.go
@@ -1,0 +1,31 @@
+// Copyright 2024 openGemini Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record
+
+func (cv *ColVal) AppendFloatNull() {
+	appendNull(cv)
+}
+
+func (cv *ColVal) AppendFloatNulls(count int) {
+	appendNulls(cv, count)
+}
+
+func (cv *ColVal) AppendFloats(values ...float64) {
+	appendValues(cv, values...)
+}
+
+func (cv *ColVal) AppendFloat(v float64) {
+	appendValue(cv, v)
+}

--- a/internal/record/column_integer.go
+++ b/internal/record/column_integer.go
@@ -1,0 +1,31 @@
+// Copyright 2024 openGemini Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record
+
+func (cv *ColVal) AppendIntegerNulls(count int) {
+	appendNulls(cv, count)
+}
+
+func (cv *ColVal) AppendIntegerNull() {
+	appendNull(cv)
+}
+
+func (cv *ColVal) AppendIntegers(values ...int64) {
+	appendValues(cv, values...)
+}
+
+func (cv *ColVal) AppendInteger(v int64) {
+	appendValue(cv, v)
+}

--- a/internal/record/column_string.go
+++ b/internal/record/column_string.go
@@ -1,0 +1,45 @@
+// Copyright 2024 openGemini Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record
+
+func (cv *ColVal) AppendStringNulls(count int) {
+	for i := 0; i < count; i++ {
+		cv.AppendStringNull()
+	}
+}
+
+func (cv *ColVal) AppendStringNull() {
+	cv.reserveOffset(1)
+	cv.Offset[cv.Len] = uint32(len(cv.Val))
+	cv.resetBitMap(cv.Len)
+	cv.Len++
+	cv.NilCount++
+}
+
+func (cv *ColVal) AppendStrings(values ...string) {
+	for _, v := range values {
+		cv.AppendString(v)
+	}
+}
+
+func (cv *ColVal) AppendString(v string) {
+	index := len(cv.Val)
+	cv.reserveVal(len(v))
+	copy(cv.Val[index:], v)
+	cv.reserveOffset(1)
+	cv.Offset[cv.Len] = uint32(index)
+	cv.setBitMap(cv.Len)
+	cv.Len++
+}

--- a/internal/record/column_util.go
+++ b/internal/record/column_util.go
@@ -1,0 +1,228 @@
+// Copyright 2024 openGemini Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record
+
+import (
+	"unsafe"
+)
+
+var (
+	BitMask        = [8]byte{1, 2, 4, 8, 16, 32, 64, 128}
+	FlippedBitMask = [8]byte{254, 253, 251, 247, 239, 223, 191, 127}
+)
+
+type ColVal struct {
+	Val          []byte
+	Offset       []uint32
+	Bitmap       []byte
+	BitMapOffset int
+	Len          int
+	NilCount     int
+}
+
+func (cv *ColVal) Init() {
+	cv.Val = cv.Val[:0]
+	cv.Offset = cv.Offset[:0]
+	cv.Bitmap = cv.Bitmap[:0]
+	cv.Len = 0
+	cv.NilCount = 0
+	cv.BitMapOffset = 0
+}
+
+func (cv *ColVal) reserveOffset(size int) {
+	offsetCap := cap(cv.Offset)
+	offsetLen := len(cv.Offset)
+	remain := offsetCap - offsetLen
+	if delta := size - remain; delta > 0 {
+		cv.Offset = append(cv.Offset[:offsetCap], make([]uint32, delta)...)
+	}
+	cv.Offset = cv.Offset[:offsetLen+size]
+}
+
+func (cv *ColVal) resetBitMap(index int) {
+	if (cv.Len+cv.BitMapOffset)>>3 >= len(cv.Bitmap) {
+		cv.Bitmap = append(cv.Bitmap, 0)
+		return
+	}
+
+	index += cv.BitMapOffset
+	cv.Bitmap[index>>3] &= FlippedBitMask[index&0x07]
+}
+
+func appendNulls(cv *ColVal, count int) {
+	for i := 0; i < count; i++ {
+		appendNull(cv)
+	}
+}
+
+func appendNull(cv *ColVal) {
+	cv.resetBitMap(cv.Len)
+	cv.Len++
+	cv.NilCount++
+}
+
+func (cv *ColVal) reserveVal(size int) {
+	cv.Val = reserveBytes(cv.Val, size)
+}
+
+func reserveBytes(b []byte, size int) []byte {
+	valCap := cap(b)
+	if valCap == 0 {
+		return make([]byte, size)
+	}
+
+	valLen := len(b)
+	remain := valCap - valLen
+	if delta := size - remain; delta > 0 {
+		if delta <= len(zeroBuf) {
+			b = append(b[:valCap], zeroBuf[:delta]...)
+		} else {
+			b = append(b[:valCap], make([]byte, delta)...)
+		}
+	}
+	return b[:valLen+size]
+}
+
+func (cv *ColVal) setBitMap(index int) {
+	if (cv.Len+cv.BitMapOffset)>>3 >= len(cv.Bitmap) {
+		cv.Bitmap = append(cv.Bitmap, 1)
+		return
+	}
+
+	index += cv.BitMapOffset
+	cv.Bitmap[index>>3] |= BitMask[index&0x07]
+}
+
+func appendValues[T ExceptString](cv *ColVal, values ...T) {
+	for _, v := range values {
+		appendValue(cv, v)
+	}
+}
+
+func appendValue[T ExceptString](cv *ColVal, v T) {
+	index := len(cv.Val)
+	cv.reserveVal(int(unsafe.Sizeof(v)))
+	*(*T)(unsafe.Pointer(&cv.Val[index])) = v
+	cv.setBitMap(cv.Len)
+	cv.Len++
+}
+
+func values[T ExceptString](cv *ColVal) []T {
+	valueLen := int(unsafe.Sizeof(*new(T)))
+	if cv.Val == nil {
+		return nil
+	}
+	data := unsafe.Slice((*T)(unsafe.Pointer(&cv.Val[0])), len(cv.Val)/valueLen)
+	return data
+}
+
+func (cv *ColVal) FloatValues() []float64 {
+	return values[float64](cv)
+}
+
+func (cv *ColVal) IsNil(i int) bool {
+	if i >= cv.Len || len(cv.Bitmap) == 0 {
+		return true
+	}
+	if cv.NilCount == 0 {
+		return false
+	}
+	idx := cv.BitMapOffset + i
+	return !((cv.Bitmap[idx>>3] & BitMask[idx&0x07]) != 0)
+}
+
+func (cv *ColVal) StringValues(dst []string) []string {
+	if len(cv.Offset) == 0 {
+		return dst
+	}
+
+	offs := cv.Offset
+	for i := 0; i < len(offs); i++ {
+		if cv.IsNil(i) {
+			continue
+		}
+		off := offs[i]
+		if i == len(offs)-1 {
+			dst = append(dst, Bytes2str(cv.Val[off:]))
+		} else {
+			dst = append(dst, Bytes2str(cv.Val[off:offs[i+1]]))
+		}
+	}
+
+	return dst
+}
+
+func (cv *ColVal) BooleanValues() []bool {
+	return values[bool](cv)
+}
+
+func (cv *ColVal) IntegerValues() []int64 {
+	return values[int64](cv)
+}
+
+func (cv *ColVal) appendAll(src *ColVal) {
+	cv.Val = append(cv.Val, src.Val...)
+	cv.Offset = append(cv.Offset, src.Offset...)
+	bitmap, bitMapOffset := subBitmapBytes(src.Bitmap, src.BitMapOffset, src.Len)
+	cv.Bitmap = append(cv.Bitmap, bitmap...)
+	cv.BitMapOffset = bitMapOffset
+	cv.Len = src.Len
+	cv.NilCount = src.NilCount
+}
+
+func subBitmapBytes(bitmap []byte, bitMapOffset int, length int) ([]byte, int) {
+	if ((bitMapOffset + length) & 0x7) != 0 {
+		return bitmap[bitMapOffset>>3 : ((bitMapOffset+length)>>3 + 1)], bitMapOffset & 0x7
+	}
+
+	return bitmap[bitMapOffset>>3 : (bitMapOffset+length)>>3], bitMapOffset & 0x7
+}
+
+func (cv *ColVal) appendString(src *ColVal, start, end int) {
+	offset := uint32(len(cv.Val))
+	for i := start; i < end; i++ {
+		if i != start {
+			offset += src.Offset[i] - src.Offset[i-1]
+		}
+		cv.Offset = append(cv.Offset, offset)
+	}
+
+	if end == src.Len {
+		cv.Val = append(cv.Val, src.Val[src.Offset[start]:]...)
+	} else {
+		cv.Val = append(cv.Val, src.Val[src.Offset[start]:src.Offset[end]]...)
+	}
+}
+
+func (cv *ColVal) Size() int {
+	size := 0
+	size += SizeOfInt()                  // Len
+	size += SizeOfInt()                  // NilCount
+	size += SizeOfInt()                  // BitMapOffset
+	size += SizeOfByteSlice(cv.Val)      // Val
+	size += SizeOfByteSlice(cv.Bitmap)   // Bitmap
+	size += SizeOfUint32Slice(cv.Offset) // Offset
+	return size
+}
+
+func (cv *ColVal) Marshal(buf []byte) ([]byte, error) {
+	buf = AppendInt(buf, cv.Len)
+	buf = AppendInt(buf, cv.NilCount)
+	buf = AppendInt(buf, cv.BitMapOffset)
+	buf = AppendBytes(buf, cv.Val)
+	buf = AppendBytes(buf, cv.Bitmap)
+	buf = AppendUint32Slice(buf, cv.Offset)
+	return buf, nil
+}

--- a/internal/record/column_util_test.go
+++ b/internal/record/column_util_test.go
@@ -1,0 +1,255 @@
+// Copyright 2024 openGemini Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestColVal_Init(t *testing.T) {
+	cv := &ColVal{
+		Val:          []byte{1, 2, 3},
+		Offset:       []uint32{0, 1, 2},
+		Bitmap:       []byte{0xFF},
+		BitMapOffset: 1,
+		Len:          3,
+		NilCount:     1,
+	}
+
+	cv.Init()
+	assert.Equal(t, 0, len(cv.Val))
+	assert.Equal(t, 0, len(cv.Offset))
+	assert.Equal(t, 0, len(cv.Bitmap))
+	assert.Equal(t, 0, cv.BitMapOffset)
+	assert.Equal(t, 0, cv.Len)
+	assert.Equal(t, 0, cv.NilCount)
+}
+
+func TestColVal_ReserveOffset(t *testing.T) {
+	cv := &ColVal{}
+
+	t.Run("reserve new offset", func(t *testing.T) {
+		cv.reserveOffset(3)
+		assert.Equal(t, 3, len(cv.Offset))
+		assert.True(t, cap(cv.Offset) >= 3)
+	})
+
+	t.Run("reserve within capacity", func(t *testing.T) {
+		originalCap := cap(cv.Offset)
+		cv.reserveOffset(1)
+		assert.Equal(t, 4, len(cv.Offset))
+		assert.Equal(t, originalCap, cap(cv.Offset))
+	})
+}
+
+func TestColVal_BitMapOperations(t *testing.T) {
+	cv := &ColVal{}
+
+	t.Run("set bitmap", func(t *testing.T) {
+		cv.setBitMap(0)
+		assert.Equal(t, byte(1), cv.Bitmap[0])
+
+		cv.setBitMap(1)
+		assert.Equal(t, byte(3), cv.Bitmap[0])
+
+		cv.setBitMap(7)
+		assert.Equal(t, byte(0x83), cv.Bitmap[0])
+	})
+
+	t.Run("reset bitmap", func(t *testing.T) {
+		cv.Init()
+		cv.Bitmap = []byte{0xFF}
+		cv.resetBitMap(0)
+		assert.Equal(t, byte(0xFE), cv.Bitmap[0])
+
+		cv.resetBitMap(1)
+		assert.Equal(t, byte(0xFC), cv.Bitmap[0])
+	})
+
+	t.Run("with bitmap offset", func(t *testing.T) {
+		cv.Init()
+		cv.BitMapOffset = 1
+		cv.setBitMap(0)
+		assert.Equal(t, byte(1), cv.Bitmap[0])
+	})
+}
+
+func TestAppendNulls(t *testing.T) {
+	cv := &ColVal{}
+
+	appendNulls(cv, 3)
+	assert.Equal(t, 3, cv.Len)
+	assert.Equal(t, 3, cv.NilCount)
+	assert.Equal(t, 1, len(cv.Bitmap))
+	assert.Equal(t, byte(0), cv.Bitmap[0])
+}
+
+func TestAppendValues(t *testing.T) {
+	t.Run("append integers", func(t *testing.T) {
+		cv := &ColVal{}
+		appendValues(cv, int64(123), int64(456))
+		assert.Equal(t, 2, cv.Len)
+		assert.Equal(t, 0, cv.NilCount)
+		assert.Equal(t, []int64{123, 456}, cv.IntegerValues())
+	})
+
+	t.Run("append floats", func(t *testing.T) {
+		cv := &ColVal{}
+		appendValues(cv, float64(1.23), float64(4.56))
+		assert.Equal(t, 2, cv.Len)
+		assert.Equal(t, 0, cv.NilCount)
+		assert.Equal(t, []float64{1.23, 4.56}, cv.FloatValues())
+	})
+
+	t.Run("append booleans", func(t *testing.T) {
+		cv := &ColVal{}
+		appendValues(cv, true, false)
+		assert.Equal(t, 2, cv.Len)
+		assert.Equal(t, 0, cv.NilCount)
+		assert.Equal(t, []bool{true, false}, cv.BooleanValues())
+	})
+}
+
+func TestColVal_StringValues(t *testing.T) {
+	cv := &ColVal{}
+
+	t.Run("empty column", func(t *testing.T) {
+		values := cv.StringValues(nil)
+		assert.Empty(t, values)
+	})
+
+	t.Run("with strings", func(t *testing.T) {
+		cv.Val = []byte("hello世界")
+		cv.Offset = []uint32{0, 5, 11}
+		cv.Bitmap = []byte{0x03}
+		cv.Len = 2
+
+		values := cv.StringValues(nil)
+		assert.Equal(t, []string{"hello", "世界"}, values)
+	})
+
+	t.Run("with nil values", func(t *testing.T) {
+		cv.Init()
+		cv.Val = []byte("test")
+		cv.Offset = []uint32{0, 4}
+		cv.Bitmap = []byte{0x01}
+		cv.Len = 2
+		cv.NilCount = 1
+
+		values := cv.StringValues(nil)
+		assert.Equal(t, []string{"test"}, values)
+	})
+}
+
+func TestColVal_IsNil(t *testing.T) {
+	cv := &ColVal{}
+
+	t.Run("empty column", func(t *testing.T) {
+		assert.True(t, cv.IsNil(0))
+	})
+
+	t.Run("no nil values", func(t *testing.T) {
+		cv.Bitmap = []byte{0xFF}
+		cv.Len = 8
+		for i := 0; i < 8; i++ {
+			assert.False(t, cv.IsNil(i))
+		}
+	})
+
+	t.Run("with nil values", func(t *testing.T) {
+		cv.Bitmap = []byte{0x0F}
+		cv.Len = 8
+		cv.NilCount = 4
+		for i := 0; i < 4; i++ {
+			assert.False(t, cv.IsNil(i))
+		}
+		for i := 4; i < 8; i++ {
+			assert.True(t, cv.IsNil(i))
+		}
+	})
+}
+
+func TestColVal_Marshal(t *testing.T) {
+	cv := &ColVal{
+		Val:          []byte{1, 2, 3},
+		Offset:       []uint32{0, 1, 2},
+		Bitmap:       []byte{0xFF},
+		BitMapOffset: 1,
+		Len:          3,
+		NilCount:     1,
+	}
+
+	buf := make([]byte, 0)
+	result, err := cv.Marshal(buf)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+
+	// Verify size calculation
+	assert.Equal(t, cv.Size(), len(result))
+}
+
+func TestColVal_AppendString(t *testing.T) {
+	src := &ColVal{
+		Val:    []byte("hello世界"),
+		Offset: []uint32{0, 5, 11},
+		Bitmap: []byte{0x03},
+		Len:    2,
+	}
+
+	t.Run("append partial", func(t *testing.T) {
+		dst := &ColVal{}
+		dst.appendString(src, 0, 1)
+		assert.Equal(t, []byte("hello"), dst.Val)
+		assert.Equal(t, []uint32{0}, dst.Offset)
+	})
+
+	t.Run("append all", func(t *testing.T) {
+		dst := &ColVal{}
+		dst.appendString(src, 0, 2)
+		assert.Equal(t, []byte("hello世界"), dst.Val)
+		assert.Equal(t, []uint32{0, 5}, dst.Offset)
+	})
+
+	t.Run("append with existing content", func(t *testing.T) {
+		dst := &ColVal{
+			Val:    []byte("test"),
+			Offset: []uint32{0},
+		}
+		dst.appendString(src, 0, 1)
+		assert.Equal(t, []byte("testhello"), dst.Val)
+		assert.Equal(t, []uint32{0, 4}, dst.Offset)
+	})
+}
+
+func TestColVal_AppendAll(t *testing.T) {
+	src := &ColVal{
+		Val:      []byte{1, 2, 3},
+		Offset:   []uint32{0, 1, 2},
+		Bitmap:   []byte{0x03},
+		Len:      2,
+		NilCount: 1,
+	}
+
+	dst := &ColVal{}
+	dst.appendAll(src)
+
+	assert.Equal(t, src.Val, dst.Val)
+	assert.Equal(t, src.Offset, dst.Offset)
+	assert.Equal(t, src.Bitmap, dst.Bitmap)
+	assert.Equal(t, src.Len, dst.Len)
+	assert.Equal(t, src.NilCount, dst.NilCount)
+}

--- a/internal/record/field.go
+++ b/internal/record/field.go
@@ -1,0 +1,76 @@
+// Copyright 2024 openGemini Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record
+
+import (
+	"strings"
+)
+
+const (
+	FieldTypeUnknown = 0
+	FieldTypeInt     = 1
+	FieldTypeUInt    = 2
+	FieldTypeFloat   = 3
+	FieldTypeString  = 4
+	FieldTypeBoolean = 5
+	FieldTypeTag     = 6
+	FieldTypeLast    = 7
+)
+
+var FieldTypeName = map[int]string{
+	FieldTypeUnknown: "Unknown",
+	FieldTypeInt:     "Integer",
+	FieldTypeUInt:    "Unsigned",
+	FieldTypeFloat:   "Float",
+	FieldTypeString:  "String",
+	FieldTypeBoolean: "Boolean",
+	FieldTypeTag:     "Tag",
+	FieldTypeLast:    "Unknown",
+}
+
+type Field struct {
+	Type int
+	Name string
+}
+
+func (f *Field) String() string {
+	var sb strings.Builder
+	sb.WriteString(f.Name)
+	sb.WriteString(FieldTypeName[f.Type])
+	return sb.String()
+}
+
+type Schemas []Field
+
+func (sh *Schemas) String() string {
+	sb := strings.Builder{}
+	for _, f := range *sh {
+		sb.WriteString(f.String() + "\n")
+	}
+	return sb.String()
+}
+
+func (f *Field) Marshal(buf []byte) ([]byte, error) {
+	buf = AppendString(buf, f.Name)
+	buf = AppendInt(buf, f.Type)
+	return buf, nil
+}
+
+func (f *Field) Size() int {
+	size := 0
+	size += SizeOfString(f.Name)
+	size += SizeOfInt()
+	return size
+}

--- a/internal/record/field_test.go
+++ b/internal/record/field_test.go
@@ -1,0 +1,195 @@
+// Copyright 2024 openGemini Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldTypeName(t *testing.T) {
+	tests := []struct {
+		fieldType int
+		expected  string
+	}{
+		{FieldTypeUnknown, "Unknown"},
+		{FieldTypeInt, "Integer"},
+		{FieldTypeUInt, "Unsigned"},
+		{FieldTypeFloat, "Float"},
+		{FieldTypeString, "String"},
+		{FieldTypeBoolean, "Boolean"},
+		{FieldTypeTag, "Tag"},
+		{FieldTypeLast, "Unknown"},
+		{999, "Unknown"}, // Invalid type should return "Unknown"
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			name, exists := FieldTypeName[tt.fieldType]
+			if tt.fieldType == 999 {
+				assert.Empty(t, name)
+				assert.False(t, exists)
+			} else {
+				assert.Equal(t, tt.expected, name)
+				assert.True(t, exists)
+			}
+		})
+	}
+}
+
+func TestField_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		field    Field
+		expected string
+	}{
+		{
+			name:     "integer field",
+			field:    Field{Type: FieldTypeInt, Name: "test_int"},
+			expected: "test_intInteger",
+		},
+		{
+			name:     "string field",
+			field:    Field{Type: FieldTypeString, Name: "test_str"},
+			expected: "test_strString",
+		},
+		{
+			name:     "unknown type field",
+			field:    Field{Type: 999, Name: "test_unknown"},
+			expected: "test_unknown",
+		},
+		{
+			name:     "empty name field",
+			field:    Field{Type: FieldTypeFloat, Name: ""},
+			expected: "Float",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.field.String()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSchemas_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		schemas  Schemas
+		expected string
+	}{
+		{
+			name: "multiple fields",
+			schemas: Schemas{
+				{Type: FieldTypeInt, Name: "field1"},
+				{Type: FieldTypeString, Name: "field2"},
+			},
+			expected: "field1Integer\nfield2String\n",
+		},
+		{
+			name:     "empty schemas",
+			schemas:  Schemas{},
+			expected: "",
+		},
+		{
+			name: "single field",
+			schemas: Schemas{
+				{Type: FieldTypeFloat, Name: "field1"},
+			},
+			expected: "field1Float\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.schemas.String()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestField_Marshal(t *testing.T) {
+	tests := []struct {
+		name      string
+		field     Field
+		initBuf   []byte
+		expectLen int
+	}{
+		{
+			name:      "empty field",
+			field:     Field{Type: FieldTypeInt, Name: ""},
+			initBuf:   []byte{},
+			expectLen: 2 + SizeOfInt(), // 2 bytes for empty string length + int size
+		},
+		{
+			name:      "normal field",
+			field:     Field{Type: FieldTypeString, Name: "test"},
+			initBuf:   []byte{1, 2, 3},
+			expectLen: 3 + 2 + 4 + SizeOfInt(), // initial 3 bytes + 2 bytes for string length + 4 bytes for "test" + int size
+		},
+		{
+			name:      "with initial buffer",
+			field:     Field{Type: FieldTypeFloat, Name: "abc"},
+			initBuf:   []byte{9, 9, 9},
+			expectLen: 3 + 2 + 3 + SizeOfInt(), // initial 3 bytes + 2 bytes for string length + 3 bytes for "abc" + int size
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.field.Marshal(tt.initBuf)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectLen, len(result))
+
+			// Verify the initial buffer is preserved
+			if len(tt.initBuf) > 0 {
+				assert.Equal(t, tt.initBuf, result[:len(tt.initBuf)])
+			}
+		})
+	}
+}
+
+func TestField_Size(t *testing.T) {
+	tests := []struct {
+		name     string
+		field    Field
+		expected int
+	}{
+		{
+			name:     "empty name",
+			field:    Field{Type: FieldTypeInt, Name: ""},
+			expected: SizeOfString("") + SizeOfInt(),
+		},
+		{
+			name:     "normal field",
+			field:    Field{Type: FieldTypeString, Name: "test"},
+			expected: SizeOfString("test") + SizeOfInt(),
+		},
+		{
+			name:     "long name",
+			field:    Field{Type: FieldTypeFloat, Name: "very_long_field_name"},
+			expected: SizeOfString("very_long_field_name") + SizeOfInt(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			size := tt.field.Size()
+			assert.Equal(t, tt.expected, size)
+		})
+	}
+}

--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -1,0 +1,204 @@
+// Copyright 2024 openGemini Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	TimeField = "time"
+)
+
+type Record struct {
+	ColVals []ColVal
+	Schema  Schemas
+}
+
+func NewRecordBuilder(schema []Field) *Record {
+	return &Record{
+		Schema:  schema,
+		ColVals: make([]ColVal, len(schema)),
+	}
+}
+
+func (rec *Record) Len() int {
+	return len(rec.Schema)
+}
+
+func (rec *Record) Swap(i, j int) {
+	rec.Schema[i], rec.Schema[j] = rec.Schema[j], rec.Schema[i]
+	rec.ColVals[i], rec.ColVals[j] = rec.ColVals[j], rec.ColVals[i]
+}
+
+func (rec *Record) Less(i, j int) bool {
+	if rec.Schema[i].Name == TimeField {
+		return false
+	} else if rec.Schema[j].Name == TimeField {
+		return true
+	} else {
+		return rec.Schema[i].Name < rec.Schema[j].Name
+	}
+}
+
+func (rec *Record) Column(i int) *ColVal {
+	return &rec.ColVals[i]
+}
+
+func (rec *Record) String() string {
+	var sb strings.Builder
+
+	for i, f := range rec.Schema {
+		var line string
+		switch f.Type {
+		case FieldTypeFloat:
+			line = fmt.Sprintf("field(%v):%#v\n", f.Name, rec.Column(i).FloatValues())
+		case FieldTypeString, FieldTypeTag:
+			line = fmt.Sprintf("field(%v):%#v\n", f.Name, rec.Column(i).StringValues(nil))
+		case FieldTypeBoolean:
+			line = fmt.Sprintf("field(%v):%#v\n", f.Name, rec.Column(i).BooleanValues())
+		case FieldTypeInt:
+			line = fmt.Sprintf("field(%v):%#v\n", f.Name, rec.Column(i).IntegerValues())
+		}
+		sb.WriteString(line)
+	}
+
+	return sb.String()
+}
+
+func CheckRecord(rec *Record) error {
+	colN := len(rec.Schema)
+	if colN <= 1 || rec.Schema[colN-1].Name != TimeField {
+		return fmt.Errorf("invalid schema: %v", rec.Schema)
+	}
+
+	if rec.ColVals[colN-1].NilCount != 0 {
+		return fmt.Errorf("invalid colvals: %v", rec.String())
+	}
+
+	for i := 1; i < colN; i++ {
+		if rec.Schema[i].Name == rec.Schema[i-1].Name {
+			return fmt.Errorf("same schema; idx: %d, name: %v", i, rec.Schema[i].Name)
+		}
+	}
+	isOrderSchema := true
+	for i := 0; i < colN-1; i++ {
+		f := &rec.Schema[i]
+		col1, col2 := &rec.ColVals[i], &rec.ColVals[i+1]
+
+		if col1.Len != col2.Len {
+			return fmt.Errorf("invalid colvals length: %v", rec.String())
+		}
+		isOrderSchema = CheckSchema(i, rec, isOrderSchema)
+
+		// check string data length
+		if f.Type == FieldTypeString || f.Type == FieldTypeTag {
+			continue
+		}
+
+		// check data length
+		expLen := typeSize[f.Type] * (col1.Len - col1.NilCount)
+		if expLen != len(col1.Val) {
+			return fmt.Errorf("the length of rec.ColVals[%d].val is incorrect. exp: %d, got: %d\n%s",
+				i, expLen, len(col1.Val), rec.String())
+		}
+	}
+	if !isOrderSchema {
+		sort.Sort(rec)
+	}
+
+	return nil
+}
+
+func CheckSchema(i int, rec *Record, isOrderSchema bool) bool {
+	if isOrderSchema && i > 0 && rec.Schema[i-1].Name >= rec.Schema[i].Name {
+		fmt.Printf("record schema is invalid; idx i-1: %d, name: %v, idx i: %d, name: %v\n",
+			i-1, rec.Schema[i-1].Name, i, rec.Schema[i].Name)
+		return false
+	}
+	return isOrderSchema
+}
+
+func (rec *Record) Reset() {
+	rec.Schema = rec.Schema[:0]
+	rec.ColVals = rec.ColVals[:0]
+}
+
+func (rec *Record) ReserveColVal(size int) {
+	// resize col val
+	colLen := len(rec.ColVals)
+	colCap := cap(rec.ColVals)
+	remain := colCap - colLen
+	if delta := size - remain; delta > 0 {
+		rec.ColVals = append(rec.ColVals[:colCap], make([]ColVal, delta)...)
+	}
+	rec.ColVals = rec.ColVals[:colLen+size]
+	rec.InitColVal(colLen, colLen+size)
+}
+
+func (rec *Record) InitColVal(start, end int) {
+	for i := start; i < end; i++ {
+		cv := &rec.ColVals[i]
+		cv.Init()
+	}
+}
+
+func (rec *Record) RowNums() int {
+	if rec == nil || len(rec.ColVals) == 0 {
+		return 0
+	}
+
+	return rec.ColVals[len(rec.ColVals)-1].Len
+}
+
+func (rec *Record) Times() []int64 {
+	if len(rec.ColVals) == 0 {
+		return nil
+	}
+	cv := rec.ColVals[len(rec.ColVals)-1]
+	return cv.IntegerValues()
+}
+
+func (rec *Record) AppendTime(time ...int64) {
+	for _, t := range time {
+		rec.ColVals[len(rec.ColVals)-1].AppendInteger(t)
+	}
+}
+
+func (rec *Record) Marshal(buf []byte) ([]byte, error) {
+	var err error
+	// Schema
+	buf = AppendUint32(buf, uint32(len(rec.Schema)))
+	for i := 0; i < len(rec.Schema); i++ {
+		buf = AppendUint32(buf, uint32(rec.Schema[i].Size()))
+		buf, err = rec.Schema[i].Marshal(buf)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// ColVal
+	buf = AppendUint32(buf, uint32(len(rec.ColVals)))
+	for i := 0; i < len(rec.ColVals); i++ {
+		buf = AppendUint32(buf, uint32(rec.ColVals[i].Size()))
+		buf, err = rec.ColVals[i].Marshal(buf)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return buf, nil
+}

--- a/internal/record/record_test.go
+++ b/internal/record/record_test.go
@@ -1,0 +1,301 @@
+// Copyright 2024 openGemini Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRecordBuilder(t *testing.T) {
+	schema := []Field{
+		{Name: "field1", Type: FieldTypeInt},
+		{Name: "field2", Type: FieldTypeString},
+		{Name: TimeField, Type: FieldTypeInt},
+	}
+
+	rec := NewRecordBuilder(schema)
+	assert.NotNil(t, rec)
+	assert.Equal(t, len(schema), len(rec.Schema))
+	assert.Equal(t, len(schema), len(rec.ColVals))
+	assert.Equal(t, schema, []Field(rec.Schema))
+}
+
+func TestRecordSort(t *testing.T) {
+	schema := []Field{
+		{Name: "field1", Type: FieldTypeInt},
+		{Name: "field2", Type: FieldTypeString},
+		{Name: TimeField, Type: FieldTypeInt},
+	}
+	rec := NewRecordBuilder(schema)
+
+	t.Run("test Less", func(t *testing.T) {
+		// TimeField should always be last
+		assert.False(t, rec.Less(2, 1)) // time vs non-time
+		assert.True(t, rec.Less(1, 2))  // non-time vs time
+		assert.True(t, rec.Less(0, 1))  // field1 vs field2
+	})
+
+	t.Run("test Swap", func(t *testing.T) {
+		rec.Swap(0, 1)
+		assert.Equal(t, "field2", rec.Schema[0].Name)
+		assert.Equal(t, "field1", rec.Schema[1].Name)
+		assert.Equal(t, TimeField, rec.Schema[2].Name)
+	})
+
+	t.Run("test Len", func(t *testing.T) {
+		assert.Equal(t, 3, rec.Len())
+	})
+}
+
+func TestRecordString(t *testing.T) {
+	schema := []Field{
+		{Name: "int_field", Type: FieldTypeInt},
+		{Name: "float_field", Type: FieldTypeFloat},
+		{Name: "bool_field", Type: FieldTypeBoolean},
+		{Name: "string_field", Type: FieldTypeString},
+		{Name: TimeField, Type: FieldTypeInt},
+	}
+	rec := NewRecordBuilder(schema)
+
+	// Add some values
+	rec.ColVals[0].AppendInteger(123)
+	rec.ColVals[1].AppendFloat(3.14)
+	rec.ColVals[2].AppendBoolean(true)
+	rec.ColVals[3].AppendString("test")
+	rec.AppendTime(1000)
+
+	str := rec.String()
+	assert.Contains(t, str, "int_field")
+	assert.Contains(t, str, "float_field")
+	assert.Contains(t, str, "bool_field")
+	assert.Contains(t, str, "string_field")
+	assert.Contains(t, str, "time")
+}
+
+func TestRecordReset(t *testing.T) {
+	schema := []Field{
+		{Name: "field1", Type: FieldTypeInt},
+		{Name: TimeField, Type: FieldTypeInt},
+	}
+	rec := NewRecordBuilder(schema)
+	rec.AppendTime(100)
+
+	rec.Reset()
+	assert.Equal(t, 0, len(rec.Schema))
+	assert.Equal(t, 0, len(rec.ColVals))
+}
+
+func TestRecordReserveColVal(t *testing.T) {
+	schema := []Field{
+		{Name: "field1", Type: FieldTypeInt},
+	}
+	rec := NewRecordBuilder(schema)
+
+	t.Run("reserve within capacity", func(t *testing.T) {
+		rec.ReserveColVal(1)
+		assert.Equal(t, 2, cap(rec.ColVals))
+		assert.Equal(t, 2, len(rec.ColVals))
+	})
+
+	t.Run("reserve beyond capacity", func(t *testing.T) {
+		rec.ReserveColVal(10)
+		assert.True(t, cap(rec.ColVals) >= 11)
+		assert.Equal(t, 12, len(rec.ColVals))
+	})
+}
+
+func TestRecordTimes(t *testing.T) {
+	schema := []Field{
+		{Name: "field1", Type: FieldTypeInt},
+		{Name: TimeField, Type: FieldTypeInt},
+	}
+	rec := NewRecordBuilder(schema)
+
+	t.Run("two fields", func(t *testing.T) {
+		assert.Equal(t, 2, rec.Len())
+	})
+
+	t.Run("with timestamps", func(t *testing.T) {
+		rec.AppendTime(100, 200, 300)
+		times := rec.Times()
+		assert.Equal(t, []int64{100, 200, 300}, times)
+	})
+}
+
+func TestRecordMarshal(t *testing.T) {
+	schema := []Field{
+		{Name: "field1", Type: FieldTypeInt},
+		{Name: TimeField, Type: FieldTypeInt},
+	}
+	rec := NewRecordBuilder(schema)
+	rec.AppendTime(100)
+
+	buf := make([]byte, 0)
+	result, err := rec.Marshal(buf)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.True(t, len(result) > 0)
+}
+
+func TestRecordRowNums(t *testing.T) {
+	t.Run("nil record", func(t *testing.T) {
+		var rec *Record
+		assert.Equal(t, 0, rec.RowNums())
+	})
+
+	t.Run("empty record", func(t *testing.T) {
+		rec := &Record{}
+		assert.Equal(t, 0, rec.RowNums())
+	})
+
+	t.Run("record with data", func(t *testing.T) {
+		schema := []Field{
+			{Name: "field1", Type: FieldTypeInt},
+			{Name: TimeField, Type: FieldTypeInt},
+		}
+		rec := NewRecordBuilder(schema)
+		rec.AppendTime(100, 200, 300)
+		assert.Equal(t, 3, rec.RowNums())
+	})
+}
+
+func TestCheckRecord(t *testing.T) {
+	t.Run("invalid record", func(t *testing.T) {
+		schema := []Field{
+			{Name: "field1", Type: FieldTypeInt},
+			{Name: TimeField, Type: FieldTypeInt},
+		}
+		rec := NewRecordBuilder(schema)
+		rec.ColVals[0].AppendInteger(123)
+		rec.AppendTime(100)
+
+		err := CheckRecord(rec)
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid time field position", func(t *testing.T) {
+		schema := []Field{
+			{Name: TimeField, Type: FieldTypeInt},
+			{Name: "field1", Type: FieldTypeInt},
+		}
+		rec := NewRecordBuilder(schema)
+		rec.ColVals[0].AppendInteger(100)
+		rec.ColVals[1].AppendInteger(123)
+
+		err := CheckRecord(rec)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid schema")
+	})
+
+	t.Run("duplicate field names", func(t *testing.T) {
+		schema := []Field{
+			{Name: "field1", Type: FieldTypeInt},
+			{Name: "field1", Type: FieldTypeInt},
+			{Name: TimeField, Type: FieldTypeInt},
+		}
+		rec := NewRecordBuilder(schema)
+		rec.ColVals[0].AppendInteger(123)
+		rec.ColVals[1].AppendInteger(456)
+		rec.AppendTime(100)
+
+		err := CheckRecord(rec)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "same schema")
+	})
+
+	t.Run("nil in time field", func(t *testing.T) {
+		schema := []Field{
+			{Name: "field1", Type: FieldTypeInt},
+			{Name: TimeField, Type: FieldTypeInt},
+		}
+		rec := NewRecordBuilder(schema)
+		rec.ColVals[0].AppendInteger(123)
+		appendNull(&rec.ColVals[1])
+
+		err := CheckRecord(rec)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid colvals")
+	})
+
+	t.Run("inconsistent column lengths", func(t *testing.T) {
+		schema := []Field{
+			{Name: "field1", Type: FieldTypeInt},
+			{Name: TimeField, Type: FieldTypeInt},
+		}
+		rec := NewRecordBuilder(schema)
+		rec.ColVals[0].AppendInteger(123)
+		rec.ColVals[0].AppendInteger(456)
+		rec.AppendTime(100)
+
+		err := CheckRecord(rec)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid colvals length")
+	})
+
+	t.Run("incorrect data length for type", func(t *testing.T) {
+		schema := []Field{
+			{Name: "field1", Type: FieldTypeInt},
+			{Name: TimeField, Type: FieldTypeInt},
+		}
+		rec := NewRecordBuilder(schema)
+		rec.ColVals[0].AppendInteger(123)
+		rec.AppendTime(100)
+
+		err := CheckRecord(rec)
+		assert.NoError(t, err)
+	})
+
+	t.Run("empty record", func(t *testing.T) {
+		rec := NewRecordBuilder(nil)
+		err := CheckRecord(rec)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid schema")
+	})
+
+	t.Run("string field type", func(t *testing.T) {
+		schema := []Field{
+			{Name: "str_field", Type: FieldTypeString},
+			{Name: TimeField, Type: FieldTypeInt},
+		}
+		rec := NewRecordBuilder(schema)
+		rec.ColVals[0].AppendString("test")
+		rec.AppendTime(100)
+
+		err := CheckRecord(rec)
+		assert.NoError(t, err) // String type does not check data length
+	})
+
+	t.Run("valid record with multiple types", func(t *testing.T) {
+		schema := []Field{
+			{Name: "int_field", Type: FieldTypeInt},
+			{Name: "float_field", Type: FieldTypeFloat},
+			{Name: "bool_field", Type: FieldTypeBoolean},
+			{Name: "string_field", Type: FieldTypeString},
+			{Name: TimeField, Type: FieldTypeInt},
+		}
+		rec := NewRecordBuilder(schema)
+
+		rec.ColVals[0].AppendInteger(123)
+		rec.ColVals[1].AppendFloat(3.14)
+		rec.ColVals[2].AppendBoolean(true)
+		rec.ColVals[3].AppendString("test")
+		rec.AppendTime(100)
+
+		err := CheckRecord(rec)
+		assert.NoError(t, err)
+	})
+}

--- a/internal/record/sort.go
+++ b/internal/record/sort.go
@@ -1,0 +1,318 @@
+// Copyright 2024 openGemini Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record
+
+import (
+	"sort"
+	"sync"
+)
+
+type ColumnSortHelper struct {
+	aux      SortAux
+	nilCount NilCount
+	times    []int64
+}
+
+type NilCount struct {
+	value []int
+	total int
+}
+
+func (nc *NilCount) init(total, size int) {
+	nc.total = total
+	if total == 0 {
+		return
+	}
+
+	if cap(nc.value) < size {
+		nc.value = make([]int, size)
+	}
+	nc.value = nc.value[:size]
+	nc.value[0] = 0
+}
+
+var columnSortHelperPool sync.Pool
+
+func NewColumnSortHelper() *ColumnSortHelper {
+	hlp, ok := columnSortHelperPool.Get().(*ColumnSortHelper)
+	if !ok || hlp == nil {
+		hlp = &ColumnSortHelper{}
+	}
+	return hlp
+}
+
+type SortAux struct {
+	RowIds   []int32
+	Times    []int64
+	sections []int
+	SortRec  *Record
+}
+
+func (aux *SortAux) Len() int {
+	return len(aux.RowIds)
+}
+
+func (aux *SortAux) Less(i, j int) bool {
+	return aux.Times[i] < aux.Times[j]
+}
+
+func (aux *SortAux) Swap(i, j int) {
+	aux.Times[i], aux.Times[j] = aux.Times[j], aux.Times[i]
+	aux.RowIds[i], aux.RowIds[j] = aux.RowIds[j], aux.RowIds[i]
+}
+
+func (aux *SortAux) Init(times []int64) {
+	aux.init(times)
+}
+
+func (aux *SortAux) init(times []int64) {
+	size := len(times)
+	if cap(aux.Times) < size {
+		aux.Times = make([]int64, size)
+	}
+	aux.Times = aux.Times[:size]
+
+	if cap(aux.RowIds) < size {
+		aux.RowIds = make([]int32, size)
+	}
+	aux.RowIds = aux.RowIds[:size]
+
+	for i := 0; i < size; i++ {
+		aux.RowIds[i] = int32(i)
+		aux.Times[i] = times[i]
+	}
+}
+
+func (rec *Record) ResetWithSchema(schema Schemas) {
+	rec.Reset()
+	rec.Schema = schema
+	rec.ReserveColVal(len(rec.Schema))
+}
+
+func (aux *SortAux) InitRecord(schemas Schemas) {
+	if aux.SortRec == nil {
+		aux.SortRec = NewRecordBuilder(schemas)
+	} else {
+		aux.SortRec.ResetWithSchema(schemas)
+	}
+}
+
+func (aux *SortAux) InitSections() {
+	times := aux.Times
+	rows := aux.RowIds
+	sections := aux.sections[:0]
+	start := 0
+
+	for i := 0; i < len(times)-1; i++ {
+		if (rows[i+1]-rows[i]) != 1 || times[i] == times[i+1] {
+			sections = append(sections, start, i)
+			start = i + 1
+			continue
+		}
+	}
+	sections = append(sections, start, len(rows)-1)
+	aux.sections = sections
+}
+
+func (aux *SortAux) RowIndex(i int) (int, int, int) {
+	start, end := aux.sections[i], aux.sections[i+1]
+	rowStat, rowEnd := int(aux.RowIds[start]), int(aux.RowIds[end]+1)
+	return start, rowStat, rowEnd
+}
+
+func (aux *SortAux) SectionLen() int {
+	return len(aux.sections)
+}
+
+func (h *ColumnSortHelper) Sort(rec *Record) *Record {
+	if rec.RowNums() == 0 {
+		return rec
+	}
+
+	aux := &h.aux
+	aux.InitRecord(rec.Schema)
+	aux.Init(rec.Times())
+	sort.Stable(aux)
+	h.times = h.times[:0]
+
+	return h.sort(rec, aux)
+}
+
+func (h *ColumnSortHelper) sort(rec *Record, aux *SortAux) *Record {
+	aux.InitSections()
+	times := aux.Times
+
+	for i := 0; i < rec.Len()-1; i++ {
+		col := rec.Column(i)
+		h.initNilCount(col, len(times)+1)
+		h.sortColumn(col, aux, i)
+	}
+
+	auxRec := aux.SortRec
+	auxRec.AppendTime(times[0])
+	for i := 1; i < len(times); i++ {
+		if times[i] != times[i-1] {
+			auxRec.AppendTime(times[i])
+		}
+	}
+
+	rec, aux.SortRec = aux.SortRec, rec
+	return rec
+}
+
+func (h *ColumnSortHelper) initNilCount(col *ColVal, size int) {
+	nc := &h.nilCount
+	nc.init(col.NilCount, size)
+	if col.NilCount == 0 {
+		return
+	}
+
+	for j := 1; j < size; j++ {
+		nc.value[j] = nc.value[j-1]
+		if col.IsNil(j - 1) {
+			nc.value[j]++
+		}
+	}
+}
+
+func (h *ColumnSortHelper) sortColumn(col *ColVal, aux *SortAux, n int) {
+	size := aux.SectionLen()
+	times := aux.Times
+	dst := aux.SortRec.Column(n)
+	typ := aux.SortRec.Schema[n].Type
+
+	for i := 0; i < size; i += 2 {
+		idx, rowStat, rowEnd := aux.RowIndex(i)
+
+		if idx > 0 && times[idx] == times[idx-1] {
+			h.replace(col, dst, typ, rowStat)
+			rowStat++
+		}
+
+		if rowStat >= rowEnd {
+			continue
+		}
+
+		dst.AppendWithNilCount(col, typ, rowStat, rowEnd, &h.nilCount)
+	}
+}
+
+func (h *ColumnSortHelper) replace(col *ColVal, aux *ColVal, typ, idx int) {
+	if col.IsNil(idx) {
+		return
+	}
+
+	aux.deleteLast(typ)
+	aux.AppendWithNilCount(col, typ, idx, idx+1, &h.nilCount)
+}
+
+func (cv *ColVal) deleteLast(typ int) {
+	if cv.Len == 0 {
+		return
+	}
+
+	isNil := cv.IsNil(cv.Len - 1)
+	cv.Len--
+	if cv.Len%8 == 0 {
+		cv.Bitmap = cv.Bitmap[:len(cv.Bitmap)-1]
+	}
+
+	defer func() {
+		if typ == FieldTypeString {
+			cv.Offset = cv.Offset[:cv.Len]
+		}
+	}()
+
+	if isNil {
+		cv.NilCount--
+		return
+	}
+
+	size := typeSize[typ]
+	if typ == FieldTypeString {
+		size = len(cv.Val) - int(cv.Offset[cv.Len])
+	}
+	cv.Val = cv.Val[:len(cv.Val)-size]
+}
+
+// AppendWithNilCount modified from method "ColVal.Append"
+// Compared with method "ColVal.Append", the number of nulls is calculated in advance.
+func (cv *ColVal) AppendWithNilCount(src *ColVal, colType, start, end int, nc *NilCount) {
+	if end <= start || src.Len == 0 {
+		return
+	}
+
+	// append all data
+	if end-start == src.Len && cv.Len == 0 {
+		cv.appendAll(src)
+		return
+	}
+
+	startOffset, endOffset := start, end
+	// Number of null values to be subtracted from the offset
+	if nc.total > 0 {
+		startOffset = start - nc.value[start]
+		endOffset = end - nc.value[end]
+	}
+
+	switch colType {
+	case FieldTypeString, FieldTypeTag:
+		cv.appendString(src, start, end)
+	case FieldTypeInt, FieldTypeFloat, FieldTypeBoolean:
+		size := typeSize[colType]
+		cv.Val = append(cv.Val, src.Val[startOffset*size:endOffset*size]...)
+	default:
+		panic("error type")
+	}
+
+	cv.appendBitmap(src.Bitmap, src.BitMapOffset, src.Len, start, end)
+	cv.Len += end - start
+	cv.NilCount += end - start - (endOffset - startOffset)
+}
+
+func (cv *ColVal) appendBitmap(bm []byte, bitOffset int, rows int, start, end int) {
+	// fast path
+	bitmap, bitMapOffset := subBitmapBytes(bm, bitOffset, rows)
+	if (cv.BitMapOffset+cv.Len)%8 == 0 && (start+bitMapOffset)%8 == 0 {
+		if (end+bitMapOffset)%8 == 0 {
+			cv.Bitmap = append(cv.Bitmap, bitmap[(start+bitMapOffset)/8:(end+bitMapOffset)/8]...)
+		} else {
+			cv.Bitmap = append(cv.Bitmap, bitmap[(start+bitMapOffset)/8:(end+bitMapOffset)/8+1]...)
+		}
+		return
+	}
+	// slow path
+	dstRowIdx := cv.BitMapOffset + cv.Len
+	addSize := (dstRowIdx+end-start+7)/8 - (dstRowIdx+7)/8
+	if addSize > 0 {
+		bLen := len(cv.Bitmap)
+		bCap := cap(cv.Bitmap)
+		remain := bCap - bLen
+		if delta := addSize - remain; delta > 0 {
+			cv.Bitmap = append(cv.Bitmap[:bCap], make([]byte, delta)...)
+		}
+		cv.Bitmap = cv.Bitmap[:bLen+addSize]
+	}
+
+	for i := 0; i < end-start; i++ {
+		cvIndex := dstRowIdx + i
+		srcIndex := bitMapOffset + start + i
+		if (bitmap[srcIndex>>3] & BitMask[srcIndex&0x07]) == 0 {
+			cv.Bitmap[cvIndex>>3] &= FlippedBitMask[cvIndex&0x07]
+		} else {
+			cv.Bitmap[cvIndex>>3] |= BitMask[cvIndex&0x07]
+		}
+	}
+}

--- a/internal/record/sort_test.go
+++ b/internal/record/sort_test.go
@@ -1,0 +1,230 @@
+// Copyright 2024 openGemini Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNilCount(t *testing.T) {
+	nc := &NilCount{}
+
+	t.Run("init with zero total", func(t *testing.T) {
+		nc.init(0, 5)
+		assert.Equal(t, 0, nc.total)
+		assert.Equal(t, 0, len(nc.value))
+	})
+
+	t.Run("init with values", func(t *testing.T) {
+		nc.init(10, 5)
+		assert.Equal(t, 10, nc.total)
+		assert.Equal(t, 5, len(nc.value))
+		assert.Equal(t, 0, nc.value[0])
+	})
+
+	t.Run("reuse existing slice", func(t *testing.T) {
+		originalCap := cap(nc.value)
+		nc.init(8, 3)
+		assert.Equal(t, originalCap, cap(nc.value))
+		assert.Equal(t, 3, len(nc.value))
+	})
+}
+
+func TestSortAux(t *testing.T) {
+	aux := &SortAux{}
+
+	t.Run("init", func(t *testing.T) {
+		times := []int64{100, 200, 150}
+		aux.Init(times)
+
+		assert.Equal(t, len(times), len(aux.Times))
+		assert.Equal(t, len(times), len(aux.RowIds))
+
+		// Check if RowIds are initialized correctly
+		for i := 0; i < len(times); i++ {
+			assert.Equal(t, int32(i), aux.RowIds[i])
+		}
+
+		// Check if Times are copied correctly
+		assert.Equal(t, times, aux.Times)
+	})
+
+	t.Run("sort interface implementation", func(t *testing.T) {
+		aux.Times = []int64{300, 100, 200}
+		aux.RowIds = []int32{0, 1, 2}
+
+		// Test Less
+		assert.False(t, aux.Less(0, 1))
+		assert.True(t, aux.Less(1, 2))
+
+		// Test Len
+		assert.Equal(t, 3, aux.Len())
+
+		// Test Swap
+		aux.Swap(0, 1)
+		assert.Equal(t, int64(100), aux.Times[0])
+		assert.Equal(t, int64(300), aux.Times[1])
+		assert.Equal(t, int32(1), aux.RowIds[0])
+		assert.Equal(t, int32(0), aux.RowIds[1])
+	})
+
+	t.Run("init sections", func(t *testing.T) {
+		aux.Times = []int64{100, 100, 200, 300, 300}
+		aux.RowIds = []int32{0, 1, 2, 3, 4}
+		aux.sections = make([]int, 0)
+
+		aux.InitSections()
+
+		// Should create sections for same timestamps and non-consecutive RowIds
+		assert.True(t, len(aux.sections) > 0)
+	})
+}
+
+func TestColumnSortHelper(t *testing.T) {
+	t.Run("new helper", func(t *testing.T) {
+		hlp := NewColumnSortHelper()
+		assert.NotNil(t, hlp)
+	})
+
+	t.Run("sort empty record", func(t *testing.T) {
+		hlp := NewColumnSortHelper()
+		rec := &Record{}
+		result := hlp.Sort(rec)
+		assert.Equal(t, rec, result)
+	})
+
+	t.Run("sort record with data", func(t *testing.T) {
+		hlp := NewColumnSortHelper()
+
+		// Create a test record with some data
+		schema := []Field{
+			{Name: "field1", Type: FieldTypeInt},
+			{Name: "field2", Type: FieldTypeFloat},
+		}
+		rec := NewRecordBuilder(schema)
+
+		// Add some timestamps
+		rec.AppendTime(200)
+		rec.AppendTime(100)
+		rec.AppendTime(300)
+
+		// Sort the record
+		sorted := hlp.Sort(rec)
+
+		// Verify timestamps are sorted
+		times := sorted.Times()
+		assert.Equal(t, int64(100), times[0])
+		assert.Equal(t, int64(200), times[1])
+		assert.Equal(t, int64(300), times[2])
+	})
+}
+
+func TestColValDeleteLast(t *testing.T) {
+	t.Run("delete from empty column", func(t *testing.T) {
+		cv := &ColVal{}
+		cv.deleteLast(FieldTypeInt)
+		assert.Equal(t, 0, cv.Len)
+	})
+
+	t.Run("delete int value", func(t *testing.T) {
+		cv := &ColVal{
+			Val:    make([]byte, 8),
+			Len:    1,
+			Bitmap: []byte{0xFF}, // not nil
+		}
+		cv.deleteLast(FieldTypeInt)
+		assert.Equal(t, 0, cv.Len)
+		assert.Equal(t, 0, len(cv.Val))
+	})
+
+	t.Run("delete nil value", func(t *testing.T) {
+		cv := &ColVal{
+			Val:      make([]byte, 8),
+			Len:      1,
+			Bitmap:   []byte{0x00}, // nil value
+			NilCount: 1,
+		}
+		cv.deleteLast(FieldTypeInt)
+		assert.Equal(t, 0, cv.Len)
+		assert.Equal(t, 0, cv.NilCount)
+	})
+
+	t.Run("delete string value", func(t *testing.T) {
+		cv := &ColVal{
+			Val:    []byte("test"),
+			Len:    1,
+			Bitmap: []byte{0xFF},
+			Offset: []uint32{0, 4},
+		}
+		cv.deleteLast(FieldTypeString)
+		assert.Equal(t, 0, cv.Len)
+		assert.Equal(t, 0, len(cv.Val))
+		assert.Equal(t, 0, len(cv.Offset))
+	})
+}
+
+func TestAppendWithNilCount(t *testing.T) {
+	t.Run("append int values", func(t *testing.T) {
+		src := &ColVal{
+			Val:    []byte{1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0},
+			Len:    2,
+			Bitmap: []byte{0xFF}, // no nil values
+		}
+		dst := &ColVal{}
+		nc := &NilCount{total: 0}
+
+		dst.AppendWithNilCount(src, FieldTypeInt, 0, 2, nc)
+		assert.Equal(t, 2, dst.Len)
+		assert.Equal(t, 16, len(dst.Val))
+		assert.Equal(t, 0, dst.NilCount)
+	})
+
+	t.Run("append with nil values", func(t *testing.T) {
+		src := &ColVal{
+			Val:      []byte{1, 0, 0, 0, 0, 0, 0, 0},
+			Len:      2,
+			Bitmap:   []byte{0x01}, // second value is nil
+			NilCount: 1,
+		}
+		dst := &ColVal{}
+		nc := &NilCount{
+			total: 1,
+			value: []int{0, 1},
+		}
+
+		dst.AppendWithNilCount(src, FieldTypeInt, 0, 2, nc)
+		assert.Equal(t, 2, dst.Len)
+		assert.Equal(t, 8, len(dst.Val))
+		assert.Equal(t, 1, dst.NilCount)
+	})
+
+	t.Run("append string values", func(t *testing.T) {
+		src := &ColVal{
+			Val:    []byte("test"),
+			Len:    1,
+			Bitmap: []byte{0xFF},
+			Offset: []uint32{0, 4},
+		}
+		dst := &ColVal{}
+		nc := &NilCount{total: 0}
+
+		dst.AppendWithNilCount(src, FieldTypeString, 0, 1, nc)
+		assert.Equal(t, 1, dst.Len)
+		assert.Equal(t, 4, len(dst.Val))
+		assert.Equal(t, 2, len(dst.Offset))
+	})
+}

--- a/internal/record/utils.go
+++ b/internal/record/utils.go
@@ -1,0 +1,124 @@
+// Copyright 2024 openGemini Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record
+
+import (
+	"unsafe"
+)
+
+const (
+	BooleanSizeBytes = int(unsafe.Sizeof(false))
+	Uint32SizeBytes  = int(unsafe.Sizeof(uint32(0)))
+	Int64SizeBytes   = int(unsafe.Sizeof(int64(0)))
+	Float64SizeBytes = int(unsafe.Sizeof(float64(0)))
+
+	sizeOfInt    = int(unsafe.Sizeof(int(0)))
+	sizeOfUint16 = 2
+	sizeOfUint32 = 4
+	MaxSliceSize = sizeOfUint32
+)
+
+var (
+	typeSize = make([]int, FieldTypeLast)
+	zeroBuf  = make([]byte, 1024)
+)
+
+func init() {
+	typeSize[FieldTypeInt] = Int64SizeBytes
+	typeSize[FieldTypeFloat] = Float64SizeBytes
+	typeSize[FieldTypeBoolean] = BooleanSizeBytes
+}
+
+type ExceptString interface {
+	int64 | float64 | bool
+}
+
+func Bytes2str(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}
+
+func AppendString(b []byte, s string) []byte {
+	b = AppendUint16(b, uint16(len(s)))
+	b = append(b, s...)
+	return b
+}
+
+// AppendUint16 appends marshaled v to dst and returns the result.
+func AppendUint16(dst []byte, u uint16) []byte {
+	return append(dst, byte(u>>8), byte(u))
+}
+
+// AppendUint32 appends marshaled v to dst and returns the result.
+func AppendUint32(dst []byte, u uint32) []byte {
+	return append(dst, byte(u>>24), byte(u>>16), byte(u>>8), byte(u))
+}
+
+// AppendInt64 appends marshaled v to dst and returns the result.
+func AppendInt64(dst []byte, v int64) []byte {
+	// Such encoding for negative v must improve compression.
+	v = (v << 1) ^ (v >> 63) // zig-zag encoding without branching.
+	u := uint64(v)
+	return append(dst, byte(u>>56), byte(u>>48), byte(u>>40), byte(u>>32), byte(u>>24), byte(u>>16), byte(u>>8), byte(u))
+}
+
+func AppendInt(b []byte, i int) []byte {
+	return AppendInt64(b, int64(i))
+}
+
+func AppendBytes(b []byte, buf []byte) []byte {
+	b = AppendUint32(b, uint32(len(buf)))
+	b = append(b, buf...)
+	return b
+}
+
+func AppendUint32Slice(b []byte, a []uint32) []byte {
+	b = AppendUint32(b, uint32(len(a)))
+	if len(a) == 0 {
+		return b
+	}
+
+	b = append(b, Uint32Slice2byte(a)...)
+	return b
+}
+
+func SizeOfString(s string) int {
+	return len(s) + sizeOfUint16
+}
+
+func SizeOfUint32() int {
+	return sizeOfUint32
+}
+
+func SizeOfInt() int {
+	return sizeOfInt
+}
+
+func SizeOfUint32Slice(s []uint32) int {
+	return len(s)*SizeOfUint32() + MaxSliceSize
+}
+
+func SizeOfByteSlice(s []byte) int {
+	return len(s) + SizeOfUint32()
+}
+
+func Uint32Slice2byte(u []uint32) []byte {
+	if len(u) == 0 {
+		return nil
+	}
+	// Get pointer to the first element of uint32 slice
+	ptr := unsafe.Pointer(unsafe.SliceData(u))
+	// Create a new byte slice from the pointer
+	return unsafe.Slice((*byte)(ptr), len(u)*Uint32SizeBytes)
+}

--- a/internal/record/utils_test.go
+++ b/internal/record/utils_test.go
@@ -1,0 +1,228 @@
+// Copyright 2024 openGemini Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBytes2str(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected string
+	}{
+		{
+			name:     "empty bytes",
+			input:    []byte{},
+			expected: "",
+		},
+		{
+			name:     "normal string",
+			input:    []byte("hello world"),
+			expected: "hello world",
+		},
+		{
+			name:     "string with special chars",
+			input:    []byte("hello\nworld\t!"),
+			expected: "hello\nworld\t!",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Bytes2str(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestAppendString(t *testing.T) {
+	tests := []struct {
+		name     string
+		initial  []byte
+		str      string
+		expected []byte
+	}{
+		{
+			name:     "empty string to empty slice",
+			initial:  []byte{},
+			str:      "",
+			expected: []byte{0, 0}, // length 0 as uint16 + empty string
+		},
+		{
+			name:     "append hello",
+			initial:  []byte{1, 2, 3},
+			str:      "hello",
+			expected: []byte{1, 2, 3, 0, 5, 'h', 'e', 'l', 'l', 'o'},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := AppendString(tt.initial, tt.str)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestUint32Slice2byte(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []uint32
+		expected int // expected length of resulting byte slice
+	}{
+		{
+			name:     "empty slice",
+			input:    []uint32{},
+			expected: 0,
+		},
+		{
+			name:     "single uint32",
+			input:    []uint32{123},
+			expected: 4, // 4 bytes per uint32
+		},
+		{
+			name:     "multiple uint32s",
+			input:    []uint32{123, 456, 789},
+			expected: 12, // 3 * 4 bytes
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Uint32Slice2byte(tt.input)
+			if tt.expected == 0 {
+				assert.Nil(t, result)
+			} else {
+				assert.Equal(t, tt.expected, len(result))
+			}
+		})
+	}
+}
+
+func TestAppendUint32Slice(t *testing.T) {
+	tests := []struct {
+		name     string
+		initial  []byte
+		slice    []uint32
+		expected int // expected length increase
+	}{
+		{
+			name:     "empty slice",
+			initial:  []byte{1, 2, 3},
+			slice:    []uint32{},
+			expected: 4, // just the length field (uint32)
+		},
+		{
+			name:     "non-empty slice",
+			initial:  []byte{1, 2, 3},
+			slice:    []uint32{123, 456},
+			expected: 12, // 4 (length) + 8 (2 * 4 bytes)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initialLen := len(tt.initial)
+			result := AppendUint32Slice(tt.initial, tt.slice)
+			assert.Equal(t, initialLen+tt.expected, len(result))
+		})
+	}
+}
+
+func TestSizeCalculations(t *testing.T) {
+	t.Run("SizeOfString", func(t *testing.T) {
+		str := "hello"
+		size := SizeOfString(str)
+		assert.Equal(t, len(str)+sizeOfUint16, size)
+	})
+
+	t.Run("SizeOfUint32", func(t *testing.T) {
+		assert.Equal(t, 4, SizeOfUint32())
+	})
+
+	t.Run("SizeOfUint32Slice", func(t *testing.T) {
+		slice := []uint32{1, 2, 3}
+		size := SizeOfUint32Slice(slice)
+		assert.Equal(t, len(slice)*4+MaxSliceSize, size)
+	})
+
+	t.Run("SizeOfByteSlice", func(t *testing.T) {
+		slice := []byte{1, 2, 3}
+		size := SizeOfByteSlice(slice)
+		assert.Equal(t, len(slice)+SizeOfUint32(), size)
+	})
+}
+
+func TestAppendIntegers(t *testing.T) {
+	t.Run("AppendUint16", func(t *testing.T) {
+		initial := []byte{1, 2, 3}
+		result := AppendUint16(initial, 258) // 258 = 0x0102
+		expected := []byte{1, 2, 3, 1, 2}
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("AppendUint32", func(t *testing.T) {
+		initial := []byte{1, 2, 3}
+		result := AppendUint32(initial, 16909060) // 16909060 = 0x01020304
+		expected := []byte{1, 2, 3, 1, 2, 3, 4}
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("AppendInt64", func(t *testing.T) {
+		initial := []byte{1, 2, 3}
+		result := AppendInt64(initial, 123)
+		assert.Equal(t, len(initial)+8, len(result))
+	})
+
+	t.Run("AppendInt", func(t *testing.T) {
+		initial := []byte{1, 2, 3}
+		result := AppendInt(initial, 123)
+		assert.Equal(t, len(initial)+8, len(result))
+	})
+}
+
+func TestAppendBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		initial  []byte
+		bytes    []byte
+		expected int // expected length increase
+	}{
+		{
+			name:     "empty bytes",
+			initial:  []byte{1, 2, 3},
+			bytes:    []byte{},
+			expected: 4, // just the length field
+		},
+		{
+			name:     "non-empty bytes",
+			initial:  []byte{1, 2, 3},
+			bytes:    []byte{4, 5, 6},
+			expected: 7, // 4 (length) + 3 (data)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initialLen := len(tt.initial)
+			result := AppendBytes(tt.initial, tt.bytes)
+			assert.Equal(t, initialLen+tt.expected, len(result))
+		})
+	}
+}


### PR DESCRIPTION
`record.Record` is a kernel module and needs to be ported to the SDK.