### PR TITLE
fix: calling the Query API, check if the Command parameter is empty

### DIFF
--- a/opengemini/error.go
+++ b/opengemini/error.go
@@ -54,3 +54,10 @@ func checkDatabaseAndPolicy(database, retentionPolicy string) error {
 	}
 	return nil
 }
+
+func checkCommand(cmd string) error {
+	if len(cmd) == 0 {
+		return ErrEmptyCommand
+	}
+	return nil
+}

--- a/opengemini/query.go
+++ b/opengemini/query.go
@@ -44,6 +44,10 @@ type Query struct {
 
 // Query sends a command to the server
 func (c *client) Query(q Query) (*QueryResult, error) {
+	if err := checkCommand(q.Command); err != nil {
+		return nil, err
+	}
+
 	req := buildRequestDetails(c.config, func(req *requestDetails) {
 		req.queryValues.Add("db", q.Database)
 		req.queryValues.Add("q", q.Command)


### PR DESCRIPTION
When calling the `Query` API, check if the Command parameter is empty.