### PR TITLE
fix: release idle connection when client close

### DIFF
--- a/opengemini/client_impl.go
+++ b/opengemini/client_impl.go
@@ -106,6 +106,7 @@ func (c *client) Close() error {
 		c.dataChanMap.Delete(key)
 		return true
 	})
+	c.cli.CloseIdleConnections()
 	return nil
 }
 


### PR DESCRIPTION
fixed: #210 

The server decides when to close the HTTP long connection, which is determined by the `ReadTimeout`, `ReadHeaderTimeout`, and `IdleTimeout` of `http.Server`. Currently, opengemini `ts-sql` does not configure these three values, which means that if the client process does not exit, the server will always keep the TCP connection KeepAlive.