### PR TITLE
feat: add precision rfc3339

### DIFF
--- a/opengemini/client.go
+++ b/opengemini/client.go
@@ -33,6 +33,7 @@ const (
 type Codec string
 
 type ContentType string
+
 type CompressMethod string
 
 const (

--- a/opengemini/point.go
+++ b/opengemini/point.go
@@ -21,6 +21,8 @@ import (
 	"time"
 )
 
+type Precision int
+
 const (
 	PrecisionNanosecond Precision = iota
 	PrecisionMicrosecond
@@ -28,9 +30,8 @@ const (
 	PrecisionSecond
 	PrecisionMinute
 	PrecisionHour
+	PrecisionRFC3339
 )
-
-type Precision int
 
 func (p Precision) String() string {
 	switch p {
@@ -46,6 +47,8 @@ func (p Precision) String() string {
 		return "PrecisionMinute"
 	case PrecisionHour:
 		return "PrecisionHour"
+	case PrecisionRFC3339:
+		return "PrecisionRFC3339"
 	}
 	return ""
 }
@@ -64,8 +67,30 @@ func (p Precision) Epoch() string {
 		return "m"
 	case PrecisionHour:
 		return "h"
+	case PrecisionRFC3339:
+		return "rfc3339"
 	}
 	return ""
+}
+
+func ToPrecision(epoch string) Precision {
+	switch epoch {
+	case "ns":
+		return PrecisionNanosecond
+	case "u":
+		return PrecisionMicrosecond
+	case "ms":
+		return PrecisionMillisecond
+	case "s":
+		return PrecisionSecond
+	case "m":
+		return PrecisionMinute
+	case "h":
+		return PrecisionHour
+	case "rfc3339":
+		return PrecisionRFC3339
+	}
+	return PrecisionNanosecond
 }
 
 // Point represents a single point in the line protocol format.

--- a/opengemini/query.go
+++ b/opengemini/query.go
@@ -22,8 +22,9 @@ import (
 	"net/http"
 	"time"
 
-	compressionPool "github.com/openGemini/opengemini-client-go/lib/pool"
 	"github.com/vmihailenco/msgpack/v5"
+
+	compressionPool "github.com/openGemini/opengemini-client-go/lib/pool"
 )
 
 const (

--- a/opengemini/query_test.go
+++ b/opengemini/query_test.go
@@ -70,6 +70,7 @@ func TestQueryWithEpoch(t *testing.T) {
 		assert.Equal(t, length, getTimestampLength(v))
 	}
 }
+
 func TestQueryWithMsgPack(t *testing.T) {
 	c := testNewClient(t, &Config{
 		Addresses: []Address{{


### PR DESCRIPTION
opengemini-server support rfc3339 precision to query and the client need to adapt to it.