### PR TITLE
fix: disable gzip by default

### DIFF
--- a/opengemini/client_impl.go
+++ b/opengemini/client_impl.go
@@ -143,6 +143,7 @@ func newHttpClient(config Config) *http.Client {
 			MaxConnsPerHost:     config.MaxConnsPerHost,
 			MaxIdleConnsPerHost: config.MaxIdleConnsPerHost,
 			TLSClientConfig:     config.TlsConfig,
+			DisableCompression:  true,
 		},
 	}
 }


### PR DESCRIPTION
The original code did not set  DisableCompression=true , which caused gzip to be enabled by default; after the fix, it is disabled, meeting the requirements.